### PR TITLE
Ensure tests running + Hostpinnacle coverage + code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+/build/

--- a/Contribution.md
+++ b/Contribution.md
@@ -8,11 +8,11 @@ Welcome and thank you for considering to improve this package. Please remember t
 
 * One pull request per feature.
 
-* Includes tests
+* Includes tests (we use **Pest** and **Orchestra Testbench**—see [README#Testing](README.md#testing)).
 
 * Document all the changes and update README.md file accordingly.
 
-* All test musts be running successfully before submitting a PR.
+* All tests must be running successfully before submitting a PR (`composer test` or `vendor/bin/pest`).
 
 Let's Gooo!
 

--- a/Pest.php
+++ b/Pest.php
@@ -1,5 +1,1 @@
 <?php
-
-use Itsmurumba\Hostpinnacle\Tests\TestCase;
-
-uses(TestCase::class)->in('tests');

--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ Or directly with Pest:
 vendor/bin/pest
 ```
 
-**Code coverage** (optional) requires a coverage driver: **PCOV** or **Xdebug**. Without one, `composer test:coverage` will report “No code coverage driver is available”.
+**Code coverage** (optional) requires a coverage driver: **PCOV** or **Xdebug**. Without one, `composer test:coverage` will report "No code coverage driver is available".
 
 - **PCOV** (line coverage, fast):  
-  - **macOS (Homebrew):** `brew tap shivammathur/extensions && brew install pcov@8.4` (use your PHP version, e.g. `pcov@8.3`). Then run coverage with that PHP: `PATH="/opt/homebrew/opt/php/bin:$PATH" composer test:coverage`.  
+  - **macOS (Homebrew):** `brew tap shivammathur/extensions && brew install pcov@8.3` (use your PHP version, e.g. `pcov@8.3`). Then run coverage with that PHP: `PATH="/opt/homebrew/opt/php/bin:$PATH" composer test:coverage`.  
   - **PECL:** `pecl install pcov` then add `extension=pcov.so` to your `php.ini`.
 - **Xdebug** (full metrics): install Xdebug and enable [coverage mode](https://xdebug.org/docs/code_coverage#mode).
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,50 @@ $data['file'] = $request->file('file');
 $response = $this->hostpinnacle->sendMobileAndMessageFileScheduledSMS($data);
 ````
 
+# Testing
+
+Tests use **[Pest](https://pestphp.com/)** (PHP testing framework) and **[Orchestra Testbench](https://orchestraplatform.com/docs/testbench)** for Laravel package testing.
+
+Run the test suite:
+
+```bash
+composer test
+```
+
+Or directly with Pest:
+
+```bash
+vendor/bin/pest
+```
+
+**Code coverage** (optional) requires a coverage driver: **PCOV** or **Xdebug**. Without one, `composer test:coverage` will report “No code coverage driver is available”.
+
+- **PCOV** (line coverage, fast):  
+  - **macOS (Homebrew):** `brew tap shivammathur/extensions && brew install pcov@8.4` (use your PHP version, e.g. `pcov@8.3`). Then run coverage with that PHP: `PATH="/opt/homebrew/opt/php/bin:$PATH" composer test:coverage`.  
+  - **PECL:** `pecl install pcov` then add `extension=pcov.so` to your `php.ini`.
+- **Xdebug** (full metrics): install Xdebug and enable [coverage mode](https://xdebug.org/docs/code_coverage#mode).
+
+If you use **Laravel Herd**, either enable PCOV or Xdebug in Herd’s PHP settings, or run coverage with a PHP that has PCOV (e.g. Homebrew as above).
+
+Then run:
+
+```bash
+composer test:coverage
+```
+
+Or with Pest:
+
+```bash
+vendor/bin/pest --coverage
+```
+
+Coverage is reported in the terminal and written to:
+
+- **HTML:** `build/coverage/index.html` (open in a browser)
+- **Clover XML:** `build/coverage/clover.xml` (for CI tools)
+
+The `build/` directory is gitignored. The `test:coverage` script creates `build/coverage` automatically.
+
 # Contribution
 This is a community package and thus welcome anyone intrested to contribute in improving the package. Kindly go through the [Contribution.md](Contribution.md) before starting to contribute. Keep those PRs and Issues coming.
 

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     },
     "scripts": {
         "test": "vendor/bin/pest",
+        "test:coverage": "mkdir -p build/coverage && vendor/bin/pest --coverage",
         "post-autoload-dump": [
             "@clear",
             "@prepare"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,8 +11,14 @@
     </testsuites>
     <source>
         <include>
-            <directory suffix=".php">./app</directory>
             <directory suffix=".php">./src</directory>
         </include>
     </source>
+    <coverage>
+        <report>
+            <html outputDirectory="build/coverage" lowUpperBound="50" highLowerBound="90"/>
+            <text outputFile="php://stdout" showUncoveredFiles="true" showOnlySummary="false"/>
+            <clover outputFile="build/coverage/clover.xml"/>
+        </report>
+    </coverage>
 </phpunit>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -45,3 +45,56 @@ function something()
 {
     // ..
 }
+
+/**
+ * Create mock file object for Hostpinnacle file-upload SMS tests.
+ * Optionally pass temp file content; returns object with getClientOriginalExtension() and __toString() (path).
+ */
+function hostpinnacle_mock_file(string $content = "Phone\n254700000000\n", string $extension = 'csv'): object
+{
+    $tempFile = tmpfile();
+    $path = stream_get_meta_data($tempFile)['uri'];
+    fwrite($tempFile, $content);
+
+    return new class($path, $tempFile, $extension) {
+        private $path;
+        private $handle;
+        private $extension;
+
+        public function __construct($path, $handle, string $extension)
+        {
+            $this->path = $path;
+            $this->handle = $handle;
+            $this->extension = $extension;
+        }
+
+        public function getClientOriginalExtension(): string
+        {
+            return $this->extension;
+        }
+
+        public function __toString(): string
+        {
+            return $this->path;
+        }
+
+        public function close(): void
+        {
+            if (is_resource($this->handle)) {
+                fclose($this->handle);
+            }
+        }
+    };
+}
+
+/**
+ * Set Hostpinnacle config for tests.
+ */
+function hostpinnacle_set_config(): void
+{
+    \Illuminate\Support\Facades\Config::set('hostpinnacle.baseUrl', 'https://api.hostpinnacle.test');
+    \Illuminate\Support\Facades\Config::set('hostpinnacle.apiKey', 'test-api-key');
+    \Illuminate\Support\Facades\Config::set('hostpinnacle.senderId', 'TESTID');
+    \Illuminate\Support\Facades\Config::set('hostpinnacle.username', 'testuser');
+    \Illuminate\Support\Facades\Config::set('hostpinnacle.password', 'testpass');
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,7 +11,9 @@
 |
 */
 
-// uses(Tests\TestCase::class)->in('Feature');
+use Itsmurumba\Hostpinnacle\Tests\TestCase;
+
+uses(TestCase::class)->in('Feature', 'Unit');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@ class TestCase extends TestbenchTestCase
     protected $hostpinnacle;
     protected $mock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->hostpinnacle = Mockery::mock('Itsmurumba\Hostpinnacle\Hostpinnacle');
@@ -30,8 +30,9 @@ class TestCase extends TestbenchTestCase
     {
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
+        parent::tearDown();
     }
 }

--- a/tests/Unit/Hostpinnacle/SendGroupSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendGroupSMSTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('sends get request with group ids', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $hostpinnacle = new Hostpinnacle();
+    $response = $hostpinnacle->sendGroupSMS([
+        'msg' => 'Group message',
+        'groupIds' => '1,2,3',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), 'https://api.hostpinnacle.test/send')
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('throws IsNullException when msg is missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+
+    $hostpinnacle->sendGroupSMS(['groupIds' => '1']);
+})->throws(IsNullException::class, 'msg and groupIds must not be null');
+
+test('throws IsNullException when groupIds is missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+
+    $hostpinnacle->sendGroupSMS(['msg' => 'Hello']);
+})->throws(IsNullException::class, 'msg and groupIds must not be null');

--- a/tests/Unit/Hostpinnacle/SendGroupScheduledSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendGroupScheduledSMSTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('sends get request with scheduleTime', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $hostpinnacle = new Hostpinnacle();
+    $response = $hostpinnacle->sendGroupScheduledSMS([
+        'msg' => 'Scheduled group msg',
+        'groupIds' => '1,2',
+        'scheduledTime' => '2025-02-02 12:00:00',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+});
+
+test('throws IsNullException when required params missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+
+    $hostpinnacle->sendGroupScheduledSMS(['msg' => 'Only message']);
+})->throws(IsNullException::class, 'msg and groupIds must not be null');

--- a/tests/Unit/Hostpinnacle/SendMobileAndMessageFileSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendMobileAndMessageFileSMSTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('sends post with file when only file required', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $file = hostpinnacle_mock_file("Phone,Message\n254700000000,Hi\n");
+    $hostpinnacle = new Hostpinnacle();
+    $response = $hostpinnacle->sendMobileAndMessageFileSMS(['file' => $file]);
+
+    expect($response->successful())->toBeTrue();
+    $file->close();
+});
+
+test('throws IsNullException when file is missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+
+    $hostpinnacle->sendMobileAndMessageFileSMS([]);
+})->throws(IsNullException::class, 'file must not be null');

--- a/tests/Unit/Hostpinnacle/SendMobileAndMessageFileScheduledSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendMobileAndMessageFileScheduledSMSTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('sends with file and scheduleTime', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $file = hostpinnacle_mock_file("Phone,Message\n254700000000,Hi\n");
+    $hostpinnacle = new Hostpinnacle();
+    $response = $hostpinnacle->sendMobileAndMessageFileScheduledSMS([
+        'file' => $file,
+        'scheduledTime' => '2025-02-04 14:00:00',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    $file->close();
+});
+
+test('throws IsNullException when file is missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+
+    $hostpinnacle->sendMobileAndMessageFileScheduledSMS(['scheduledTime' => '2025-02-04 14:00:00']);
+})->throws(IsNullException::class, 'file must not be null');

--- a/tests/Unit/Hostpinnacle/SendMobileOnlyFileSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendMobileOnlyFileSMSTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('sends post with file attachment', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $file = hostpinnacle_mock_file("Phone\n254700000000\n");
+    $hostpinnacle = new Hostpinnacle();
+    $response = $hostpinnacle->sendMobileOnlyFileSMS([
+        'msg' => 'Bulk message',
+        'file' => $file,
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    $file->close();
+});
+
+test('throws IsNullException when msg is missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+    $file = new class {
+        public function getClientOriginalExtension()
+        {
+            return 'csv';
+        }
+    };
+
+    $hostpinnacle->sendMobileOnlyFileSMS(['file' => $file]);
+})->throws(IsNullException::class, 'msg and file must not be null');
+
+test('throws IsNullException when file is missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+
+    $hostpinnacle->sendMobileOnlyFileSMS(['msg' => 'No file']);
+})->throws(IsNullException::class, 'msg and file must not be null');

--- a/tests/Unit/Hostpinnacle/SendMobileOnlyFileScheduledSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendMobileOnlyFileScheduledSMSTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('sends with scheduleTime', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $file = hostpinnacle_mock_file("Phone\n254700000000\n");
+    $hostpinnacle = new Hostpinnacle();
+    $response = $hostpinnacle->sendMobileOnlyFileScheduledSMS([
+        'msg' => 'Scheduled bulk',
+        'file' => $file,
+        'scheduledTime' => '2025-02-03 09:00:00',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    $file->close();
+});

--- a/tests/Unit/Hostpinnacle/SendQuickSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendQuickSMSTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('sends post request with correct payload', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $hostpinnacle = new Hostpinnacle();
+    $response = $hostpinnacle->sendQuickSMS([
+        'msg' => 'Hello World',
+        'mobile' => '254700000000',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/send'
+            && $request['msg'] === 'Hello World'
+            && $request['mobile'] === '254700000000'
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('throws IsNullException when msg is missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+
+    $hostpinnacle->sendQuickSMS(['mobile' => '254700000000']);
+})->throws(IsNullException::class, 'msg and mobile must not be null');
+
+test('throws IsNullException when mobile is missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+
+    $hostpinnacle->sendQuickSMS(['msg' => 'Hello']);
+})->throws(IsNullException::class, 'msg and mobile must not be null');
+
+test('throws IsNullException when both msg and mobile are missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+
+    $hostpinnacle->sendQuickSMS([]);
+})->throws(IsNullException::class, 'msg and mobile must not be null');

--- a/tests/Unit/Hostpinnacle/SendQuickScheduledSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendQuickScheduledSMSTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('sends post with scheduleTime', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $hostpinnacle = new Hostpinnacle();
+    $response = $hostpinnacle->sendQuickScheduledSMS([
+        'msg' => 'Scheduled message',
+        'mobile' => '254711111111',
+        'scheduledTime' => '2025-02-01 10:00:00',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request['scheduleTime'] === '2025-02-01 10:00:00';
+    });
+});
+
+test('throws IsNullException when msg or mobile is missing', function () {
+    $hostpinnacle = new Hostpinnacle();
+
+    $hostpinnacle->sendQuickScheduledSMS(['msg' => 'Hi']);
+})->throws(IsNullException::class, 'msg and mobile must not be null');

--- a/tests/Unit/InstallHostpinnaclePackageTest.php
+++ b/tests/Unit/InstallHostpinnaclePackageTest.php
@@ -4,30 +4,34 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Artisan;
 
 test('the install command copies the configuration', function () {
-    if (File::exists(config_path('hostpinnacle.php'))) {
-        unlink(config_path('hostpinnacle.php'));
+    $configPath = $this->app->configPath('hostpinnacle.php');
+
+    if (File::exists($configPath)) {
+        unlink($configPath);
     }
 
-    expect(File::exists(config_path('hostpinnacle.php')))->toBeFalse();
+    expect(File::exists($configPath))->toBeFalse();
 
     Artisan::call('hostpinnacle:install');
 
-    expect(File::exists(config_path('hostpinnacle.php')))->toBeTrue();
+    expect(File::exists($configPath))->toBeTrue();
 });
 
 test('when a config file is present users can choose not to overwrite it', function () {
-    File::put(config_path('hostpinnacle.php'), 'test contents');
-    expect(File::exists(config_path('hostpinnacle.php')))->toBeTrue();
+    $configPath = $this->app->configPath('hostpinnacle.php');
 
-    $command = $this->artisan('hostpinnacle:install');
+    File::put($configPath, 'test contents');
+    expect(File::exists($configPath))->toBeTrue();
 
-    $command->expectsConfirmation(
-        'Config file already exists. Do you want to overwrite it?',
-        'no'
-    );
+    $this->artisan('hostpinnacle:install')
+        ->expectsConfirmation(
+            'Config file already exists. Do you want to overwrite it?',
+            'no'
+        )
+        ->expectsOutput('Exiting. Hostpinnacle configuration was not overwritten')
+        ->run();
 
-    $command->expectsOutput('Exiting. Hostpinnacle configuration was not overwritten');
-    expect(file_get_contents(config_path('hostpinnacle.php')))->toBe('test contents');
+    expect(file_get_contents($configPath))->toBe('test contents');
 
-    unlink(config_path('hostpinnacle.php'));
+    unlink($configPath);
 });


### PR DESCRIPTION
## Summary

This branch fixes the Pest/Testbench test setup so all tests run and pass, adds unit tests for the `Hostpinnacle` class (split by method), and adds code coverage support with documentation.

**Branch:** `ensure-tests-running` → `main`

---

## What changed

### 1. Test setup (Pest + Testbench)

- **TestCase binding:** Apply `TestCase` to all tests in `Feature` and `Unit` via `uses(TestCase::class)->in('Feature', 'Unit')` in `tests/Pest.php` so Testbench/Laravel app is available in tests.
- **InstallHostpinnaclePackageTest:**
  - Use `$this->app->configPath('hostpinnacle.php')` instead of `config_path()` so tests work under Testbench.
  - Call `->run()` on the artisan command so it runs during the test (before assertions and `unlink`), fixing the “config file present, user chooses not to overwrite” case.
- **TestCase:** Make `setUp()` and `tearDown()` `protected` for Pest’s Testable trait; call `parent::tearDown()` in `tearDown()`.
- **Root Pest.php:** Reduced to a minimal file; TestCase binding lives in `tests/Pest.php`.

### 2. Hostpinnacle unit tests

- **19 new tests** for `Hostpinnacle`, grouped by method in `tests/Unit/Hostpinnacle/`:
  - `SendQuickSMSTest.php` – `sendQuickSMS` (payload + validation)
  - `SendQuickScheduledSMSTest.php` – `sendQuickScheduledSMS`
  - `SendGroupSMSTest.php` – `sendGroupSMS`
  - `SendGroupScheduledSMSTest.php` – `sendGroupScheduledSMS`
  - `SendMobileOnlyFileSMSTest.php` – `sendMobileOnlyFileSMS`
  - `SendMobileOnlyFileScheduledSMSTest.php` – `sendMobileOnlyFileScheduledSMS`
  - `SendMobileAndMessageFileSMSTest.php` – `sendMobileAndMessageFileSMS`
  - `SendMobileAndMessageFileScheduledSMSTest.php` – `sendMobileAndMessageFileScheduledSMS`
- **Helpers in `tests/Pest.php`:**
  - `hostpinnacle_set_config()` – set Hostpinnacle config for tests.
  - `hostpinnacle_mock_file($content, $extension)` – mock file object for file-upload SMS tests.

Tests use Laravel’s `Http::fake()` and `Http::assertSent()`; validation tests assert `IsNullException` for missing required params.

### 3. Code coverage

- **phpunit.xml:** `<coverage>` with HTML report to `build/coverage`, text to stdout, and Clover XML to `build/coverage/clover.xml`. Source limited to `./src`.
- **composer.json:** `test:coverage` runs `mkdir -p build/coverage && vendor/bin/pest --coverage`.
- **.gitignore:** Added `/build/`.
- **README:** Testing section documents Pest/Testbench, coverage requirement (PCOV or Xdebug), install steps for macOS Homebrew and PECL, Laravel Herd note, and report paths.
- **Contribution.md:** Mentions Pest/Testbench and test commands.

Coverage requires PCOV or Xdebug; README explains how to install and run coverage (e.g. Homebrew: `brew tap shivammathur/extensions && brew install pcov@8.4`, then run with that PHP).

---

## Commits (8)

1. **Ensure all Pest/Testbench tests run and pass** – TestCase binding, InstallHostpinnaclePackageTest fixes, TestCase visibility.
2. **Add Hostpinnacle test helpers to Pest.php** – `hostpinnacle_set_config()`, `hostpinnacle_mock_file()`.
3. **Add Hostpinnacle tests: sendQuickSMS and sendQuickScheduledSMS**
4. **Add Hostpinnacle tests: sendGroupSMS and sendGroupScheduledSMS**
5. **Add Hostpinnacle tests: sendMobileOnlyFileSMS and sendMobileOnlyFileScheduledSMS**
6. **Add Hostpinnacle tests: sendMobileAndMessageFileSMS and sendMobileAndMessageFileScheduledSMS**
7. **Add code coverage support and documentation** – phpunit.xml coverage, composer script, .gitignore, README, Contribution.md.

---

## Testing

- **Run full suite:** `composer test` or `vendor/bin/pest`
- **Run Hostpinnacle tests only:** `vendor/bin/pest tests/Unit/Hostpinnacle`
- **Run with coverage:** `composer test:coverage` or `vendor/bin/pest --coverage` (requires PCOV or Xdebug; see README)

**Expected:** All 23 tests pass (41 assertions). With coverage driver: ~92% total coverage (HTML at `build/coverage/index.html`, Clover at `build/coverage/clover.xml`).

---

## Files changed (summary)

| Path | Change |
|------|--------|
| `Pest.php` | Simplified (TestCase moved to tests/Pest.php) |
| `tests/Pest.php` | TestCase binding + Hostpinnacle helpers |
| `tests/TestCase.php` | `setUp`/`tearDown` protected, `parent::tearDown()` |
| `tests/Unit/InstallHostpinnaclePackageTest.php` | config path + command `->run()` |
| `tests/Unit/Hostpinnacle/*.php` | 8 new test files (19 tests) |
| `phpunit.xml` | Source `./src` only; `<coverage>` with HTML, text, Clover |
| `composer.json` | `test:coverage` script |
| `.gitignore` | `/build/` |
| `README.md` | Testing + coverage section |
| `Contribution.md` | Pest/Testbench + test commands |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests covering SMS send and scheduled flows, file-upload scenarios, and test helpers to simplify test setup.

* **Documentation**
  * Added a new "Testing" section with setup, run and coverage instructions.

* **Chores**
  * Enabled coverage reporting, added a test:coverage script, and gitignored the build/ output directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->