### PR TITLE
SaaS / Multi-Account + VitePress docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /vendor/
 /build/
+
+# Docs (VitePress)
+node_modules/
+docs/.vitepress/cache/
+docs/.vitepress/dist/

--- a/README.md
+++ b/README.md
@@ -33,11 +33,46 @@ $response = Hostpinnacle::sendQuickSMS([
 ]);
 ```
 
+## Testing the package locally (before publishing)
+
+To try the package in a real Laravel app without publishing to Packagist:
+
+**1. Path repository (recommended)** — In your Laravel app’s `composer.json` add a path repo and require the package:
+
+```json
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/path/to/laravel-hostpinnacle"
+        }
+    ],
+    "require": {
+        "itsmurumba/laravel-hostpinnacle": "@dev"
+    }
+}
+```
+
+Then run `composer update`, add your Hostpinnacle env vars, and use the package as normal (e.g. `Hostpinnacle::sendQuickSMS(...)`). Changes in the package folder are used immediately (no re-publish).
+
+**2. From a Git branch** — To test the install as users will (from GitHub), push your branch and in the app use:
+
+```json
+{
+    "repositories": [{"type": "vcs", "url": "https://github.com/ItsMurumba/laravel-hostpinnacle"}],
+    "require": {
+        "itsmurumba/laravel-hostpinnacle": "dev-feature/saas-multi-account"
+    }
+}
+```
+
+Replace the branch name with yours. Run `composer update` in the app. Good for checking that `composer.json` and the repo are correct before a public release.
+
 ## Documentation
 
 Full documentation (installation, configuration, usage, SaaS multi-account, testing, config reference) is built with [VitePress](https://vitepress.dev/) and lives in the **`docs/`** folder.
 
-- **Local:** Run `npm install` then `npm run docs:dev` and open http://localhost:5173.
+- **Local:** Run `npm install` then `npm run docs:dev` and open http://localhost:5174.
 - **Build:** `npm run docs:build` — output in `docs/.vitepress/dist/` (suitable for GitHub Pages or any static host).
 
 For GitHub Pages (project site), set `base: '/laravel-hostpinnacle/'` in `docs/.vitepress/config.mts` before building. For a custom domain, keep `base: '/'`.

--- a/README.md
+++ b/README.md
@@ -1,240 +1,51 @@
-## laravel-hostpinnacle
-Official laravel package for Hostpinnacle SMS Service(API). It includes all public available endpoints:
-* Quick SMS
-* Group SMS
-* File Upload
+# Laravel Hostpinnacle
 
-## Installation
+Official Laravel package for the **Hostpinnacle SMS API**. Quick SMS, Group SMS, and File Upload — with optional **SaaS multi-account** support.
 
-Run the following command to install Laravel Hostpinnacle package in your project:
+## Quick start
 
-````
+```bash
 composer require itsmurumba/laravel-hostpinnacle
-````
+```
 
-If you are using **Laravel 5.5** and above, skip to the [**Configurations**](https://github.com/ItsMurumba/laravel-hostpinnacle#configurations) step.
-
-After running the composer require above, you should add a service provider and alias of the package in config/app.php file.(For Laravel 5.4 and below)
-
-````
-Itsmurumba\Hostpinnacle\HostpinnacleServiceProvider::class
-````
-
-# Configurations
-
-After installing the package, run the following command to install `hostpinnacle.php` configuartion file in the `config` folder:
-
-````
+```bash
 php artisan hostpinnacle:install
-````
+```
 
-or 
-````
-php artisan vendor:publish
-````
+Add to `.env`:
 
-Add and define the following variables in your `.env` file
-
-````
-HOSTPINNACLE_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxx
-HOSTPINNACLE_SENDER_ID=xxxxxxxxxx
-HOSTPINNACLE_LOGIN_USERNAME=xxxxxxxxxxxxxxx
-HOSTPINNACLE_LOGIN_PASSWORD=xxxxxx
+```env
+HOSTPINNACLE_API_KEY=your-api-key
+HOSTPINNACLE_SENDER_ID=your-sender-id
+HOSTPINNACLE_LOGIN_USERNAME=your-username
+HOSTPINNACLE_LOGIN_PASSWORD=your-password
 HOSTPINNACLE_BASE_URL=https://smsportal.hostpinnacle.co.ke/SMSApi
-````
+```
 
-## Usage
-Add the following constructor inside your controller:
-`````
-protected $hostpinnacle;
+Send SMS:
 
-public function __construct(){
-    $this->hostpinnacle = new Hostpinnacle();
-}
-`````
-**1. Quick SMS**
-
-a. Sending a quick SMS (Batch)
-````
-$data['mobile'] = '254720xxxxxx';
-$data['msg'] = 'Hello World!';
-
-$response = $this->hostpinnacle->sendQuickSMS($data);
-````
-
-b. Sending a quick scheduled SMS (Batch)
-````
-$data['scheduledTime'] = '2023-02-28 17:32:03';
-$data['mobile'] = '254720xxxxxx';
-$data['msg'] = 'Hello World!';
-
-$response = $this->hostpinnacle->sendQuickScheduledSMS($data);
-````
-
-**2. Group SMS**
-
-a. Sending a Group SMS
-````
-$data['groupIds'] = '1056';
-$data['msg'] = 'Hello World!';
-
-$response = $this->hostpinnacle->sendGroupSMS($data);
-````
-
-b. Sending a Group Scheduled SMS
-````
-$data['scheduledTime'] = '2023-02-28 17:32:03';
-$data['groupIds'] = '1056';
-$data['msg'] = 'Hello World!';
-
-$response = $this->hostpinnacle->sendGroupScheduledSMS($data);
-````
-**3. File Upload SMS**
-
-a. Sending an SMS from File with Mobile Numbers only
-````
-$data['file'] = $request->file('file');
-$data['msg'] = 'Hello World!';
-
-$response = $this->hostpinnacle->sendMobileOnlyFileSMS($data);
-````
-
-b. Sending an SMS from File with Mobile Numbers only Scheduled
-````
-$data['scheduledTime'] = '2023-02-28 17:32:03';
-$data['file'] = $request->file('file');
-$data['msg'] = 'Hello World !';
-
-$response = $this->hostpinnacle->sendMobileOnlyFileScheduledSMS($data);
-````
-c. Sending an SMS from File with Mobile Numbers and message
-````
-$data['file'] = $request->file('file');
-
-$response = $this->hostpinnacle->sendMobileAndMessageFileSMS($data);
-````
-
-d. Sending an SMS from File with Mobile Numbers and message Scheduled
-````
-$data['scheduledTime'] = '2023-02-28 17:32:03';
-$data['file'] = $request->file('file');
-
-$response = $this->hostpinnacle->sendMobileAndMessageFileScheduledSMS($data);
-````
-
-You can also use the **facade** (single-account, env-based credentials):
-
-````
+```php
 use Itsmurumba\Hostpinnacle\Facades\Hostpinnacle;
 
-$response = Hostpinnacle::sendQuickSMS(['mobile' => '254720xxxxxx', 'msg' => 'Hello World!']);
-````
-
----
-
-## SaaS / Multi-Account (optional)
-
-If you run a SaaS where each customer has their own Hostpinnacle account, you can enable **multi-account** mode. Each tenant/user stores their own credentials in the database and sends SMS using their account. Single-account usage above is unchanged.
-
-### Enable SaaS
-
-1. **Config:** In `config/hostpinnacle.php`, set `saas.enabled` to `true` (or set `HOSTPINNACLE_SAAS_ENABLED=true` in `.env`).
-
-2. **Migration:** Publish and run the accounts table:
-   ````
-   php artisan vendor:publish --tag=hostpinnacle-migrations
-   php artisan migrate
-   ````
-
-3. **Routes (optional):** The package registers **API** and **Web** routes for CRUD on Hostpinnacle accounts when SaaS is enabled. You can turn them on/off in config:
-   - **API routes** — JSON; for SPAs, mobile apps, or Vue/React calling the API (e.g. `api/hostpinnacle/accounts`). Use `saas.api_routes_enabled` and middleware such as `auth:sanctum`.
-   - **Web routes** — same CRUD under `web` + `auth`; support form submissions (redirect + flash) or AJAX with `Accept: application/json`. Use `saas.web_routes_enabled`. Path prefix defaults to `hostpinnacle` (e.g. `hostpinnacle/accounts`).
-
-   Build your own UI (Blade, Vue, SPA, etc.) and call these endpoints or use the `HostpinnacleAccount` model directly.
-
-### Sending SMS as a stored account
-
-Resolve the account (e.g. for the current user or tenant), then use the facade:
-
-````
-use Itsmurumba\Hostpinnacle\Facades\Hostpinnacle;
-use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
-
-$account = HostpinnacleAccount::where('user_id', auth()->id())->first(); // or your owner key
-$response = Hostpinnacle::for($account)->sendQuickSMS(['mobile' => '254720xxxxxx', 'msg' => 'Hello!']);
-````
-
-You can also pass `HostpinnacleCredentials` to `Hostpinnacle::for($credentials)` if you have a value object instead of a model.
-
-### Config options (SaaS)
-
-| Key | Description |
-|-----|-------------|
-| `saas.enabled` | Turn on multi-account features (migrations, routes, `Hostpinnacle::for()`). |
-| `saas.table` | Table name for accounts (default: `hostpinnacle_accounts`). |
-| `saas.owner_type` / `saas.owner_key` / `saas.owner_model` | Owner of an account (e.g. `user`, `user_id`, `App\Models\User`). |
-| `saas.encrypt_password` | Encrypt password in DB (default: true). |
-| `saas.api_routes_enabled` / `saas.web_routes_enabled` | Enable API and/or Web CRUD routes. |
-| `saas.api_prefix` / `saas.web_prefix` | Route prefixes (e.g. `api`, `hostpinnacle`). |
-| `saas.api_middleware` / `saas.web_middleware` | Middleware for API and Web routes. |
-
-### Security (SaaS)
-
-- Use **HTTPS** in production so credentials are not sent in clear text.
-- Passwords (and optionally API keys) are stored encrypted when `saas.encrypt_password` is true.
-- Do not log credentials; the package masks `api_key` in API responses and never returns `password`.
-
----
-
-# Testing
-
-Tests use **[Pest](https://pestphp.com/)** (PHP testing framework) and **[Orchestra Testbench](https://orchestraplatform.com/docs/testbench)** for Laravel package testing.
-
-Run the test suite:
-
-```bash
-composer test
+$response = Hostpinnacle::sendQuickSMS([
+    'mobile' => '254720xxxxxx',
+    'msg' => 'Hello World!',
+]);
 ```
 
-Or directly with Pest:
+## Documentation
 
-```bash
-vendor/bin/pest
-```
+Full documentation (installation, configuration, usage, SaaS multi-account, testing, config reference) is built with [VitePress](https://vitepress.dev/) and lives in the **`docs/`** folder.
 
-**Code coverage** (optional) requires a coverage driver: **PCOV** or **Xdebug**. Without one, `composer test:coverage` will report "No code coverage driver is available".
+- **Local:** Run `npm install` then `npm run docs:dev` and open http://localhost:5173.
+- **Build:** `npm run docs:build` — output in `docs/.vitepress/dist/` (suitable for GitHub Pages or any static host).
 
-- **PCOV** (line coverage, fast):  
-  - **macOS (Homebrew):** `brew tap shivammathur/extensions && brew install pcov@8.3` (use your PHP version, e.g. `pcov@8.3`). Then run coverage with that PHP: `PATH="/opt/homebrew/opt/php/bin:$PATH" composer test:coverage`.  
-  - **PECL:** `pecl install pcov` then add `extension=pcov.so` to your `php.ini`.
-- **Xdebug** (full metrics): install Xdebug and enable [coverage mode](https://xdebug.org/docs/code_coverage#mode).
+For GitHub Pages (project site), set `base: '/laravel-hostpinnacle/'` in `docs/.vitepress/config.mts` before building. For a custom domain, keep `base: '/'`.
 
-If you use **Laravel Herd**, either enable PCOV or Xdebug in Herd’s PHP settings, or run coverage with a PHP that has PCOV (e.g. Homebrew as above).
+## Contributing
 
-Then run:
+Contributions are welcome. Please read [Contribution.md](Contribution.md) before submitting PRs or issues.
 
-```bash
-composer test:coverage
-```
+## License
 
-Or with Pest:
-
-```bash
-vendor/bin/pest --coverage
-```
-
-Coverage is reported in the terminal and written to:
-
-- **HTML:** `build/coverage/index.html` (open in a browser)
-- **Clover XML:** `build/coverage/clover.xml` (for CI tools)
-
-The `build/` directory is gitignored. The `test:coverage` script creates `build/coverage` automatically.
-
-# Contribution
-This is a community package and thus welcome anyone intrested to contribute in improving the package. Kindly go through the [Contribution.md](Contribution.md) before starting to contribute. Keep those PRs and Issues coming.
-
-# Buy Me Coffee
-Give this repo a star and i will have my super powers recharged. You can also follow me on twitter [@ItsMurumba](https://twitter.com/ItsMurumba)
-
-# License
-This package is licensed under the MIT License. Please review the [License](LICENSE.md) file for details
+MIT. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,70 @@ $data['file'] = $request->file('file');
 $response = $this->hostpinnacle->sendMobileAndMessageFileScheduledSMS($data);
 ````
 
+You can also use the **facade** (single-account, env-based credentials):
+
+````
+use Itsmurumba\Hostpinnacle\Facades\Hostpinnacle;
+
+$response = Hostpinnacle::sendQuickSMS(['mobile' => '254720xxxxxx', 'msg' => 'Hello World!']);
+````
+
+---
+
+## SaaS / Multi-Account (optional)
+
+If you run a SaaS where each customer has their own Hostpinnacle account, you can enable **multi-account** mode. Each tenant/user stores their own credentials in the database and sends SMS using their account. Single-account usage above is unchanged.
+
+### Enable SaaS
+
+1. **Config:** In `config/hostpinnacle.php`, set `saas.enabled` to `true` (or set `HOSTPINNACLE_SAAS_ENABLED=true` in `.env`).
+
+2. **Migration:** Publish and run the accounts table:
+   ````
+   php artisan vendor:publish --tag=hostpinnacle-migrations
+   php artisan migrate
+   ````
+
+3. **Routes (optional):** The package registers **API** and **Web** routes for CRUD on Hostpinnacle accounts when SaaS is enabled. You can turn them on/off in config:
+   - **API routes** — JSON; for SPAs, mobile apps, or Vue/React calling the API (e.g. `api/hostpinnacle/accounts`). Use `saas.api_routes_enabled` and middleware such as `auth:sanctum`.
+   - **Web routes** — same CRUD under `web` + `auth`; support form submissions (redirect + flash) or AJAX with `Accept: application/json`. Use `saas.web_routes_enabled`. Path prefix defaults to `hostpinnacle` (e.g. `hostpinnacle/accounts`).
+
+   Build your own UI (Blade, Vue, SPA, etc.) and call these endpoints or use the `HostpinnacleAccount` model directly.
+
+### Sending SMS as a stored account
+
+Resolve the account (e.g. for the current user or tenant), then use the facade:
+
+````
+use Itsmurumba\Hostpinnacle\Facades\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
+
+$account = HostpinnacleAccount::where('user_id', auth()->id())->first(); // or your owner key
+$response = Hostpinnacle::for($account)->sendQuickSMS(['mobile' => '254720xxxxxx', 'msg' => 'Hello!']);
+````
+
+You can also pass `HostpinnacleCredentials` to `Hostpinnacle::for($credentials)` if you have a value object instead of a model.
+
+### Config options (SaaS)
+
+| Key | Description |
+|-----|-------------|
+| `saas.enabled` | Turn on multi-account features (migrations, routes, `Hostpinnacle::for()`). |
+| `saas.table` | Table name for accounts (default: `hostpinnacle_accounts`). |
+| `saas.owner_type` / `saas.owner_key` / `saas.owner_model` | Owner of an account (e.g. `user`, `user_id`, `App\Models\User`). |
+| `saas.encrypt_password` | Encrypt password in DB (default: true). |
+| `saas.api_routes_enabled` / `saas.web_routes_enabled` | Enable API and/or Web CRUD routes. |
+| `saas.api_prefix` / `saas.web_prefix` | Route prefixes (e.g. `api`, `hostpinnacle`). |
+| `saas.api_middleware` / `saas.web_middleware` | Middleware for API and Web routes. |
+
+### Security (SaaS)
+
+- Use **HTTPS** in production so credentials are not sent in clear text.
+- Passwords (and optionally API keys) are stored encrypted when `saas.encrypt_password` is true.
+- Do not log credentials; the package masks `api_key` in API responses and never returns `password`.
+
+---
+
 # Testing
 
 Tests use **[Pest](https://pestphp.com/)** (PHP testing framework) and **[Orchestra Testbench](https://orchestraplatform.com/docs/testbench)** for Laravel package testing.

--- a/config/hostpinnacle.php
+++ b/config/hostpinnacle.php
@@ -50,4 +50,28 @@ return [
     |
     */
     'baseUrl' => getenv('HOSTPINNACLE_BASE_URL'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | SaaS / Multi-Account
+    |--------------------------------------------------------------------------
+    |
+    | Enable and configure multi-account (per-tenant) Hostpinnacle credentials
+    | stored in the database. When disabled, only env-based credentials are used.
+    |
+    */
+    'saas' => [
+        'enabled' => env('HOSTPINNACLE_SAAS_ENABLED', false),
+        'table' => 'hostpinnacle_accounts',
+        'owner_type' => env('HOSTPINNACLE_SAAS_OWNER_TYPE', 'user'),
+        'owner_key' => env('HOSTPINNACLE_SAAS_OWNER_KEY', 'user_id'),
+        'owner_model' => env('HOSTPINNACLE_SAAS_OWNER_MODEL', 'App\\Models\\User'),
+        'encrypt_password' => env('HOSTPINNACLE_SAAS_ENCRYPT_PASSWORD', true),
+        'api_routes_enabled' => env('HOSTPINNACLE_SAAS_API_ROUTES_ENABLED', true),
+        'web_routes_enabled' => env('HOSTPINNACLE_SAAS_WEB_ROUTES_ENABLED', true),
+        'api_prefix' => env('HOSTPINNACLE_SAAS_API_PREFIX', 'api'),
+        'web_prefix' => env('HOSTPINNACLE_SAAS_WEB_PREFIX', 'hostpinnacle'),
+        'api_middleware' => ['api', 'auth:sanctum'],
+        'web_middleware' => ['web', 'auth'],
+    ],
 ];

--- a/config/hostpinnacle.php
+++ b/config/hostpinnacle.php
@@ -65,6 +65,7 @@ return [
         'table' => 'hostpinnacle_accounts',
         'owner_type' => env('HOSTPINNACLE_SAAS_OWNER_TYPE', 'user'),
         'owner_key' => env('HOSTPINNACLE_SAAS_OWNER_KEY', 'user_id'),
+        'owner_key_type' => env('HOSTPINNACLE_SAAS_OWNER_KEY_TYPE', 'unsignedBigInteger'),
         'owner_model' => env('HOSTPINNACLE_SAAS_OWNER_MODEL', 'App\\Models\\User'),
         'encrypt_password' => env('HOSTPINNACLE_SAAS_ENCRYPT_PASSWORD', true),
         'api_routes_enabled' => env('HOSTPINNACLE_SAAS_API_ROUTES_ENABLED', true),

--- a/database/migrations/2025_01_31_000000_create_hostpinnacle_accounts_table.php
+++ b/database/migrations/2025_01_31_000000_create_hostpinnacle_accounts_table.php
@@ -8,6 +8,9 @@ return new class extends Migration
 {
     /**
      * Run the migrations.
+     *
+     * Table name and owner column come from config. Set saas.table and saas.owner_key
+     * before running this migration; do not change them after, or the model will not match the schema.
      */
     public function up(): void
     {

--- a/database/migrations/2025_01_31_000000_create_hostpinnacle_accounts_table.php
+++ b/database/migrations/2025_01_31_000000_create_hostpinnacle_accounts_table.php
@@ -9,17 +9,26 @@ return new class extends Migration
     /**
      * Run the migrations.
      *
-     * Table name and owner column come from config. Set saas.table and saas.owner_key
-     * before running this migration; do not change them after, or the model will not match the schema.
+     * Table name, owner column name and owner column type come from config. Set
+     * saas.table, saas.owner_key and saas.owner_key_type before running this
+     * migration; do not change them after, or the model will not match the schema.
+     *
+     * owner_key_type: unsignedBigInteger (default), uuid, or string. Use uuid or
+     * string when your owner model uses a UUID or string primary key.
      */
     public function up(): void
     {
         $tableName = config('hostpinnacle.saas.table', 'hostpinnacle_accounts');
         $ownerKey = config('hostpinnacle.saas.owner_key', 'user_id');
+        $ownerKeyType = config('hostpinnacle.saas.owner_key_type', 'unsignedBigInteger');
 
-        Schema::create($tableName, function (Blueprint $table) use ($ownerKey) {
+        Schema::create($tableName, function (Blueprint $table) use ($ownerKey, $ownerKeyType) {
             $table->id();
-            $table->unsignedBigInteger($ownerKey)->nullable()->index();
+            match ($ownerKeyType) {
+                'uuid' => $table->uuid($ownerKey)->nullable()->index(),
+                'string' => $table->string($ownerKey)->nullable()->index(),
+                default => $table->unsignedBigInteger($ownerKey)->nullable()->index(),
+            };
             $table->string('api_key');
             $table->string('sender_id');
             $table->string('username');

--- a/database/migrations/2025_01_31_000000_create_hostpinnacle_accounts_table.php
+++ b/database/migrations/2025_01_31_000000_create_hostpinnacle_accounts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $tableName = config('hostpinnacle.saas.table', 'hostpinnacle_accounts');
+        $ownerKey = config('hostpinnacle.saas.owner_key', 'user_id');
+
+        Schema::create($tableName, function (Blueprint $table) use ($ownerKey) {
+            $table->id();
+            $table->unsignedBigInteger($ownerKey)->nullable()->index();
+            $table->string('api_key');
+            $table->string('sender_id');
+            $table->string('username');
+            $table->text('password');
+            $table->string('base_url')->nullable();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tableName = config('hostpinnacle.saas.table', 'hostpinnacle_accounts');
+        Schema::dropIfExists($tableName);
+    }
+};

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -7,6 +7,11 @@ export default defineConfig({
   base: '/',
   // For GitHub Pages project site (user.github.io/laravel-hostpinnacle), use:
   // base: '/laravel-hostpinnacle/',
+  vite: {
+    server: {
+      port: 5174,
+    },
+  },
   themeConfig: {
     nav: [
       { text: 'Guide', link: '/guide/installation' },
@@ -22,6 +27,7 @@ export default defineConfig({
           { text: 'Usage', link: '/guide/usage' },
           { text: 'SaaS / Multi-Account', link: '/guide/saas-multi-account' },
           { text: 'Testing', link: '/guide/testing' },
+          { text: 'Testing locally (before publish)', link: '/guide/testing-locally-before-publish' },
         ],
       },
       {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,49 @@
+import { defineConfig } from 'vitepress'
+
+// https://vitepress.dev/reference/site-config
+export default defineConfig({
+  title: 'Laravel Hostpinnacle',
+  description: 'Official Laravel package for Hostpinnacle SMS API — Quick SMS, Group SMS, File Upload. Single-account and SaaS multi-account support.',
+  base: '/',
+  // For GitHub Pages project site (user.github.io/laravel-hostpinnacle), use:
+  // base: '/laravel-hostpinnacle/',
+  themeConfig: {
+    nav: [
+      { text: 'Guide', link: '/guide/installation' },
+      { text: 'Reference', link: '/reference/config' },
+      { text: 'Contributing', link: '/contributing/implementation-outline' },
+    ],
+    sidebar: [
+      {
+        text: 'Guide',
+        items: [
+          { text: 'Installation', link: '/guide/installation' },
+          { text: 'Configuration', link: '/guide/configuration' },
+          { text: 'Usage', link: '/guide/usage' },
+          { text: 'SaaS / Multi-Account', link: '/guide/saas-multi-account' },
+          { text: 'Testing', link: '/guide/testing' },
+        ],
+      },
+      {
+        text: 'Reference',
+        items: [
+          { text: 'Config Options', link: '/reference/config' },
+        ],
+      },
+      {
+        text: 'Contributing',
+        items: [
+          { text: 'SaaS Implementation Outline', link: '/contributing/implementation-outline' },
+        ],
+      },
+    ],
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/ItsMurumba/laravel-hostpinnacle' },
+      { icon: 'twitter', link: 'https://twitter.com/ItsMurumba' },
+    ],
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright © 2019-present',
+    },
+  },
+})

--- a/docs/SAAS-MULTI-ACCOUNT-IMPLEMENTATION-OUTLINE.md
+++ b/docs/SAAS-MULTI-ACCOUNT-IMPLEMENTATION-OUTLINE.md
@@ -1,0 +1,252 @@
+# Hostpinnacle Package: SaaS / Multi-Account Implementation Outline
+
+This document outlines how to extend the Laravel Hostpinnacle package to support **both**:
+
+1. **Single-account (current):** One set of credentials via env variables (`HOSTPINNACLE_*`), used app-wide. Ideal for single-tenant apps.
+2. **Multi-account (SaaS):** Each customer/tenant configures their own Hostpinnacle credentials (via an UI that **you** build), stored in the database, and sends SMS from their own account. Ideal for SaaS where each customer has their own Hostpinnacle account.
+
+The design keeps existing usage unchanged and adds optional, opt-in behaviour for SaaS. **Account management is exposed via both API and Web routes** (no UI shipped), so implementers can build their own interface and choose the style that fits:
+- **API routes** — JSON in/out; for SPAs, mobile apps, or Vue/React front-ends that call the API (e.g. axios to `api/hostpinnacle/accounts`).
+- **Web routes** — same CRUD actions under the `web` middleware; support both classic form submissions (redirects with flash messages) and AJAX/JSON (e.g. Laravel with inbuilt Vue posting to web routes with `Accept: application/json`). Ideal for Blade + Vue hybrid apps that prefer web middleware and session-based auth.
+Optionally, example views can be provided later as a reference only.
+
+---
+
+## 1. Current Architecture (Reference)
+
+| Component | Behaviour |
+|-----------|-----------|
+| **Config** (`config/hostpinnacle.php`) | Reads `apiKey`, `senderId`, `username`, `password`, `baseUrl` from env. |
+| **Hostpinnacle class** | Constructor calls `setApiKey()`, `setBaseUrl()`, `setSenderId()`, `setUsername()`, `setPassword()` which all use `Config::get('hostpinnacle.*')`. No way to inject credentials. |
+| **Service provider** | Binds `'laravel-hostpinnacle'` → `new Hostpinnacle()` (no args). |
+| **Facade** | `Hostpinnacle` facade resolves to `'hostpinnacle'` (note: provider binds `'laravel-hostpinnacle'`; alignment should be verified). |
+| **SMS methods** | All use `$this->apiKey`, `$this->baseUrl`, `$this->username`, `$this->password`, `$this->senderId` (from constructor). |
+
+Credentials are therefore **global and fixed** per app instance. To support SaaS we need **per-request or per-tenant credentials** without breaking `new Hostpinnacle()` or `Hostpinnacle::sendQuickSMS(...)`.
+
+---
+
+## 2. Design Principles
+
+- **Backward compatible:** Existing apps that use env + facade or `new Hostpinnacle()` continue to work with no code changes.
+- **Explicit over implicit:** SaaS usage explicitly passes or resolves “which account” (e.g. `Hostpinnacle::for($account)`), rather than magic global state.
+- **Package-agnostic tenancy:** The package does not assume “user” or “tenant”; it provides storage and a resolver that the app configures (e.g. by user, team, or tenant id).
+- **API and Web routes, no UI in package:** Migration + model + controller(s) and **both API and Web** route groups for account CRUD. The package does **not** ship any UI; implementers build their own. **API routes** return JSON (for SPAs, mobile, or Vue/React calling the API). **Web routes** use `web` middleware and support classic form posts (redirect + flash) and AJAX (e.g. Laravel with inbuilt Vue posting with `Accept: application/json`). Config can enable API and/or Web routes separately. Optionally, the package can later provide *example* views as a reference only.
+
+---
+
+## 3. Proposed Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        Application                                       │
+├─────────────────────────────────────────────────────────────────────────┤
+│  Single-account (current)          │  Multi-account (SaaS)              │
+│  • Hostpinnacle facade              │  • HostpinnacleAccount model      │
+│  • new Hostpinnacle()               │  • Hostpinnacle::for($account)     │
+│  • Credentials from Config (env)    │  • Credentials from DB             │
+└─────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Hostpinnacle class                                                     │
+│  Constructor: Hostpinnacle(?HostpinnacleCredentials $credentials = null) │
+│  • If $credentials === null → load from Config (current behaviour)      │
+│  • If $credentials provided → use them (new behaviour)                  │
+└─────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  HostpinnacleCredentials (value object)                                  │
+│  apiKey, senderId, username, password, baseUrl                           │
+│  • From config array or from HostpinnacleAccount model                   │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Implementation Outline
+
+### Phase 1: Credentials abstraction (no breaking changes)
+
+**4.1 Introduce `HostpinnacleCredentials` (value object)**
+
+- **Location:** `src/HostpinnacleCredentials.php` (or `src/Support/HostpinnacleCredentials.php`).
+- **Purpose:** Encapsulate the five values (apiKey, senderId, username, password, baseUrl) so they can be passed into `Hostpinnacle` or created from config/DB.
+- **API (suggestion):**
+  - Constructor: `__construct(string $apiKey, string $senderId, string $username, string $password, ?string $baseUrl = null)`.
+  - Optional: `static fromConfig(): self` (reads from `Config::get('hostpinnacle')`).
+  - Optional: `static fromArray(array $array): self`.
+  - Getters for each property (or public readonly properties in PHP 8+).
+- **baseUrl:** If not provided, use a default from config or package constant so single-account behaviour is unchanged.
+
+**4.2 Refactor `Hostpinnacle` to accept optional credentials**
+
+- **Constructor:** `public function __construct(?HostpinnacleCredentials $credentials = null)`.
+  - If `$credentials === null`: load credentials via `HostpinnacleCredentials::fromConfig()` (or equivalent) and assign to properties (current behaviour).
+  - If `$credentials` is provided: use it to set `$this->apiKey`, `$this->baseUrl`, etc., and do **not** read from Config.
+- **Internal:** Replace direct `Config::get(...)` in setters with logic that either uses the injected credentials or falls back to config (only when constructed without credentials). Prefer a single code path: “resolve credentials once in constructor.”
+- **No change** to public SMS method signatures; they continue to use `$this->apiKey`, `$this->username`, etc.
+- **Tests:** Existing tests that use `Config::set('hostpinnacle.*')` and `new Hostpinnacle()` must still pass. Add tests for `new Hostpinnacle($credentials)` using a `HostpinnacleCredentials` instance.
+
+**4.3 Service provider and facade (single-account)**
+
+- Keep binding that returns `new Hostpinnacle()` (no args) so the facade and `app('laravel-hostpinnacle')` (or `app('hostpinnacle')`) still use config-based credentials.
+- Fix facade accessor if it currently points to `'hostpinnacle'` while the provider binds `'laravel-hostpinnacle'` so that both refer to the same binding and behaviour is consistent.
+
+---
+
+### Phase 2: Storage and model for SaaS accounts
+
+**4.4 Migration: `hostpinnacle_accounts` table**
+
+- **Purpose:** Store one Hostpinnacle “account” (credentials) per tenant/customer/user.
+- **Suggested columns:**
+  - `id` (bigInteger, primary key).
+  - **Owner reference (configurable):** e.g. `user_id` (nullable), or a polymorphic `accountable_type` + `accountable_id`, or `tenant_id` — see 4.5.
+  - `api_key` (string).
+  - `sender_id` (string).
+  - `username` (string).
+  - `password` (string); consider encryption at rest (Laravel `encrypted` cast or custom).
+  - `base_url` (string, nullable) — default from config if null.
+  - `name` (string, nullable) — optional label, e.g. “Main account”.
+  - `timestamps`.
+- **Index:** Index owner columns (e.g. `user_id` or `accountable_type, accountable_id`) for “list accounts for current tenant” queries.
+- **Publishing:** Migration published via `php artisan vendor:publish --tag=hostpinnacle-migrations`. Optional: run in package service provider if config says `hostpinnacle.saas.enabled` or similar.
+
+**4.5 Model: `HostpinnacleAccount`**
+
+- **Location:** `src/Models/HostpinnacleAccount.php` (or `src/HostpinnacleAccount.php`).
+- **Relations:** BelongsTo user (or polymorphic “accountable”) as per migration. Relationship name configurable via config (e.g. `hostpinnacle.saas.owner_relation`).
+- **Credentials:** Method `toCredentials(): HostpinnacleCredentials` that returns a value object from the model’s attributes (and decrypts password if needed).
+- **Security:** Use `encrypted` cast for `password` (and optionally `api_key`) so DB stores encrypted values.
+- **Config:** Config key, e.g. `hostpinnacle.saas.owner_key` (`user_id` vs `tenant_id` vs polymorphic) so the app can adapt without code change.
+
+**4.6 Config additions**
+
+- **File:** `config/hostpinnacle.php` (extend published config).
+- **New keys (suggestion):**
+  - `hostpinnacle.saas.enabled` (bool) — turn on SaaS features (migrations, routes, “for account” API).
+  - `hostpinnacle.saas.owner_type` — e.g. `user` (then we use `user_id`), or `tenant`, or `polymorphic`.
+  - `hostpinnacle.saas.table` — table name, default `hostpinnacle_accounts`.
+  - `hostpinnacle.saas.encrypt_password` (bool) — whether to encrypt password in DB.
+  - **Routes:** `saas.api_routes_enabled` (bool), `saas.web_routes_enabled` (bool); optional `saas.api_prefix`, `saas.web_prefix`, `saas.api_middleware`, `saas.web_middleware` so implementers can use API only, Web only, or both (e.g. API for SPAs, Web for Laravel with inbuilt Vue).
+
+This keeps the package usable for different SaaS shapes (per-user, per-tenant, etc.) without hardcoding “User” in the package.
+
+---
+
+### Phase 3: Resolver / factory for “send as this account”
+
+**4.7 Factory or static helper**
+
+- **Option A – Factory class:** `HostpinnacleFactory` with method `for(HostpinnacleAccount|HostpinnacleCredentials $accountOrCredentials): Hostpinnacle`. Registered as singleton; creates a new `Hostpinnacle` instance with the given credentials each time (no shared state).
+- **Option B – Facade method:** `Hostpinnacle::for(HostpinnacleAccount $account)` that returns a new `Hostpinnacle` instance configured with `$account->toCredentials()`. Internally this can call the same factory.
+- **Recommendation:** Implement a small `HostpinnacleFactory` that both the facade and the app can use; facade exposes `Hostpinnacle::for($account)` for convenience.
+
+**4.8 Usage in SaaS app (example)**
+
+- **Store account:** User fills a form (API Key, Sender ID, Username, Password, Base URL); app saves to `hostpinnacle_accounts` with `user_id` (or tenant id, etc.).
+- **Send SMS as that account:** In a controller, resolve the account (e.g. `auth()->user()->hostpinnacleAccount` or first active account), then:
+  - `Hostpinnacle::for($account)->sendQuickSMS([...])`  
+  or  
+  - `app(HostpinnacleFactory::class)->for($account)->sendQuickSMS([...])`.
+- **Single-account app:** No change; continue using `Hostpinnacle::sendQuickSMS([...])` or `app('hostpinnacle')->sendQuickSMS([...])` with env-based credentials.
+
+---
+
+### Phase 4: API and Web routes for managing accounts (no UI in package)
+
+**4.9 Controller and shared logic**
+
+- **Scope:** The package provides **both API and Web routes** for CRUD of Hostpinnacle accounts. No UI is shipped; implementers build their own (Blade, Vue, SPA, mobile, etc.) and call either the API or the web endpoints.
+- **Controller:** e.g. `HostpinnacleAccountController` — `index`, `store`, `update`, `destroy` (and optionally `show`). Resolve “current owner” from config (e.g. `auth()->user()->id`). Validate input (required fields, format). Use policy or middleware so only the owner can manage their accounts.
+- **Response format (single controller for both):**
+  - When the request expects JSON (`Accept: application/json` or `request()->wantsJson()`): always return JSON (resource or array). Used by API routes and by AJAX calls from Vue/Blade (e.g. axios with `Accept: application/json`).
+  - When the request is a normal web request (e.g. form POST from Blade): return `redirect()->back()->with('success', ...)` or `redirect()->route(...)` and use session flash for errors. So Laravel apps with inbuilt Vue can use classic forms that post to web routes and get redirects, or Vue components that call the same web routes and get JSON.
+- **API resources:** Optional `HostpinnacleAccountResource` for consistent JSON; mask or omit sensitive fields (e.g. mask `api_key`, never return `password`).
+
+**4.10 API routes**
+
+- **Purpose:** For SPAs, mobile apps, or any client that calls a dedicated API (e.g. Vue/React app using axios to `api/...`).
+- **Registration:** Only if `hostpinnacle.saas.enabled` and e.g. `hostpinnacle.saas.api_routes_enabled` are true. Prefix: `api` (or configurable). Middleware: e.g. `auth:sanctum` or `auth:api` (configurable).
+- **Actions:** Same controller as web; routes point to same methods. Controller detects API route (or `wantsJson()`) and returns JSON.
+
+**4.11 Web routes**
+
+- **Purpose:** For Laravel apps using **web** stack (Blade, Laravel with inbuilt Vue, session-based auth). Supports (a) classic form submissions → redirect + flash, and (b) Vue/Blade AJAX (e.g. axios to same URL with `Accept: application/json`) → JSON response.
+- **Registration:** Only if `hostpinnacle.saas.enabled` and e.g. `hostpinnacle.saas.web_routes_enabled` are true. Middleware: `web`, `auth` (or configurable). No `api` prefix; use a path prefix such as `hostpinnacle/accounts` (configurable).
+- **Actions:** Same controller; store/update/destroy return redirect when not `wantsJson()`, else JSON.
+
+**4.12 Config for routes**
+
+- **Suggested keys:** `saas.api_routes_enabled` (bool), `saas.web_routes_enabled` (bool), optional `saas.api_prefix`, `saas.web_prefix`, `saas.api_middleware`, `saas.web_middleware`. Defaults: both enabled when SaaS is enabled; standard `api` and `web` middleware.
+
+**4.13 Example UI (optional, out of scope for initial release)**
+
+- The package **does not** ship production UI. If desired later, *example* views (e.g. simple Blade forms or Vue components) could be provided as a **reference only** — e.g. in a separate repo or as publishable “example” stubs (e.g. `hostpinnacle-example-views`) so implementers know they are optional. This keeps the core package lean and UI-agnostic.
+
+---
+
+### Phase 5: Documentation and backward compatibility
+
+**4.14 README / docs**
+
+- **Single-account (existing):** Keep current “Configurations” and “Usage” (env vars, `Hostpinnacle::sendQuickSMS(...)`). State that this is unchanged.
+- **SaaS / multi-account:** New section:
+  - Enable SaaS in config.
+  - Run migration (`hostpinnacle_accounts`).
+  - **API routes:** Use for SPAs, mobile, or Vue/React calling the API (JSON). Enable with `saas.api_routes_enabled`.
+  - **Web routes:** Use for Laravel with inbuilt Vue/Blade (form posts → redirects, or AJAX with `Accept: application/json` → JSON). Enable with `saas.web_routes_enabled`. Ideal for non-API settings (session auth, Blade + Vue).
+  - Use the package’s API or Web routes (or the model directly) for CRUD; build your own UI.
+  - Resolve account (e.g. from current user) and call `Hostpinnacle::for($account)->sendQuickSMS(...)`.
+  - Example: “Resolving account for current user” (e.g. `auth()->user()->hostpinnacleAccount` or `HostpinnacleAccount::forUser(auth()->id())->first()`).
+- **Security:** Recommend HTTPS, encrypted storage for password (and optionally api_key), and not logging credentials.
+
+**4.15 Backward compatibility checklist**
+
+- [x] Existing app with only env set and no new config keys: no errors; same behaviour as today.
+- [x] `new Hostpinnacle()` with no args: uses Config (env).
+- [x] `Hostpinnacle::sendQuickSMS(...)` (facade, no “for”): uses default binding (env).
+- [x] No new required env vars; no required new tables unless the app opts in to SaaS.
+- [x] All existing tests pass; new tests for credentials object and “for account” path.
+
+---
+
+## 5. File / Component Summary
+
+| Component | Action |
+|-----------|--------|
+| `HostpinnacleCredentials` | **New** — value object for the five credentials. |
+| `Hostpinnacle` | **Refactor** — constructor accepts optional `?HostpinnacleCredentials`; internal resolution from config only when null. |
+| `HostpinnacleAccount` model | **New** — Eloquent model, `toCredentials()`, encrypted password (optional). |
+| Migration `hostpinnacle_accounts` | **New** — publishable; owner column(s) configurable. |
+| `HostpinnacleFactory` | **New** — `for(Account|Credentials): Hostpinnacle`. |
+| `HostpinnacleServiceProvider` | **Extend** — register factory; optionally register routes; fix facade binding if needed. |
+| `Hostpinnacle` Facade | **Extend** — add `Hostpinnacle::for($account)` if desired. |
+| Config `hostpinnacle.php` | **Extend** — add `saas.enabled`, `saas.owner_*`, `saas.table`, `saas.api_routes_enabled`, `saas.web_routes_enabled`, etc. |
+| API and Web Controller / Routes / Resources | **New** — optional, config-gated; CRUD via **API** routes (JSON) and **Web** routes (redirect or JSON); no UI in package. |
+| README / docs | **Update** — single-account unchanged; new SaaS section. |
+
+---
+
+## 6. Suggested Implementation Order
+
+1. **Phase 1:** Credentials object + refactor `Hostpinnacle` constructor + tests. No new config keys or DB. Ensures zero breakage and sets the base for “per-account” usage.
+2. **Phase 2:** Config additions, migration, `HostpinnacleAccount` model, `toCredentials()`.
+3. **Phase 3:** Factory + `Hostpinnacle::for($account)` (or equivalent) and a minimal test sending SMS with a stored account.
+4. **Phase 4:** Controller (shared logic), **API routes** and **Web routes** for account CRUD, API resources; gate behind config (api_routes_enabled, web_routes_enabled). No UI in package.
+5. **Phase 5:** README and any extra docs; final backward-compatibility pass and tests.
+
+---
+
+## 7. Security Considerations
+
+- **Passwords (and optionally API keys)** in `hostpinnacle_accounts`: store encrypted (Laravel `encrypted` cast or `Crypt::encryptString`). Decrypt only when building `HostpinnacleCredentials` for sending.
+- **API:** Validate and sanitise all inputs; use Laravel validation rules. Never expose raw credentials in API responses (e.g. mask `api_key` in index/show, omit password).
+- **Authorization:** Only the “owner” (user/tenant) of an account can update or delete it; enforce in controller and, if applicable, policy.
+- **HTTPS:** Document that production should use HTTPS so credentials are not sent in clear text.
+
+---
+
+This outline should be enough to implement single-account and SaaS multi-account support in a backward-compatible way. Once this is agreed, implementation can proceed phase by phase with tests at each step.

--- a/docs/contributing/implementation-outline.md
+++ b/docs/contributing/implementation-outline.md
@@ -5,7 +5,7 @@ This document outlines how to extend the Laravel Hostpinnacle package to support
 1. **Single-account (current):** One set of credentials via env variables (`HOSTPINNACLE_*`), used app-wide. Ideal for single-tenant apps.
 2. **Multi-account (SaaS):** Each customer/tenant configures their own Hostpinnacle credentials (via an UI that **you** build), stored in the database, and sends SMS from their own account. Ideal for SaaS where each customer has their own Hostpinnacle account.
 
-The design keeps existing usage unchanged and adds optional, opt-in behaviour for SaaS. **Account management is exposed via both API and Web routes** (no UI shipped), so implementers can build their own interface and choose the style that fits:
+The design keeps existing usage unchanged and adds optional, opt-in behaviour for SaaS. **Account management is exposed via both API and Web routes** (no UI shipped), so implementers build their own interface and choose the style that fits:
 - **API routes** — JSON in/out; for SPAs, mobile apps, or Vue/React front-ends that call the API (e.g. axios to `api/hostpinnacle/accounts`).
 - **Web routes** — same CRUD actions under the `web` middleware; support both classic form submissions (redirects with flash messages) and AJAX/JSON (e.g. Laravel with inbuilt Vue posting to web routes with `Accept: application/json`). Ideal for Blade + Vue hybrid apps that prefer web middleware and session-based auth.
 Optionally, example views can be provided later as a reference only.
@@ -29,8 +29,8 @@ Credentials are therefore **global and fixed** per app instance. To support SaaS
 ## 2. Design Principles
 
 - **Backward compatible:** Existing apps that use env + facade or `new Hostpinnacle()` continue to work with no code changes.
-- **Explicit over implicit:** SaaS usage explicitly passes or resolves “which account” (e.g. `Hostpinnacle::for($account)`), rather than magic global state.
-- **Package-agnostic tenancy:** The package does not assume “user” or “tenant”; it provides storage and a resolver that the app configures (e.g. by user, team, or tenant id).
+- **Explicit over implicit:** SaaS usage explicitly passes or resolves "which account" (e.g. `Hostpinnacle::for($account)`), rather than magic global state.
+- **Package-agnostic tenancy:** The package does not assume "user" or "tenant"; it provides storage and a resolver that the app configures (e.g. by user, team, or tenant id).
 - **API and Web routes, no UI in package:** Migration + model + controller(s) and **both API and Web** route groups for account CRUD. The package does **not** ship any UI; implementers build their own. **API routes** return JSON (for SPAs, mobile, or Vue/React calling the API). **Web routes** use `web` middleware and support classic form posts (redirect + flash) and AJAX (e.g. Laravel with inbuilt Vue posting with `Accept: application/json`). Config can enable API and/or Web routes separately. Optionally, the package can later provide *example* views as a reference only.
 
 ---
@@ -85,7 +85,7 @@ Credentials are therefore **global and fixed** per app instance. To support SaaS
 - **Constructor:** `public function __construct(?HostpinnacleCredentials $credentials = null)`.
   - If `$credentials === null`: load credentials via `HostpinnacleCredentials::fromConfig()` (or equivalent) and assign to properties (current behaviour).
   - If `$credentials` is provided: use it to set `$this->apiKey`, `$this->baseUrl`, etc., and do **not** read from Config.
-- **Internal:** Replace direct `Config::get(...)` in setters with logic that either uses the injected credentials or falls back to config (only when constructed without credentials). Prefer a single code path: “resolve credentials once in constructor.”
+- **Internal:** Replace direct `Config::get(...)` in setters with logic that either uses the injected credentials or falls back to config (only when constructed without credentials). Prefer a single code path: "resolve credentials once in constructor."
 - **No change** to public SMS method signatures; they continue to use `$this->apiKey`, `$this->username`, etc.
 - **Tests:** Existing tests that use `Config::set('hostpinnacle.*')` and `new Hostpinnacle()` must still pass. Add tests for `new Hostpinnacle($credentials)` using a `HostpinnacleCredentials` instance.
 
@@ -100,7 +100,7 @@ Credentials are therefore **global and fixed** per app instance. To support SaaS
 
 **4.4 Migration: `hostpinnacle_accounts` table**
 
-- **Purpose:** Store one Hostpinnacle “account” (credentials) per tenant/customer/user.
+- **Purpose:** Store one Hostpinnacle "account" (credentials) per tenant/customer/user.
 - **Suggested columns:**
   - `id` (bigInteger, primary key).
   - **Owner reference (configurable):** e.g. `user_id` (nullable), or a polymorphic `accountable_type` + `accountable_id`, or `tenant_id` — see 4.5.
@@ -109,16 +109,16 @@ Credentials are therefore **global and fixed** per app instance. To support SaaS
   - `username` (string).
   - `password` (string); consider encryption at rest (Laravel `encrypted` cast or custom).
   - `base_url` (string, nullable) — default from config if null.
-  - `name` (string, nullable) — optional label, e.g. “Main account”.
+  - `name` (string, nullable) — optional label, e.g. "Main account".
   - `timestamps`.
-- **Index:** Index owner columns (e.g. `user_id` or `accountable_type, accountable_id`) for “list accounts for current tenant” queries.
+- **Index:** Index owner columns (e.g. `user_id` or `accountable_type, accountable_id`) for "list accounts for current tenant" queries.
 - **Publishing:** Migration published via `php artisan vendor:publish --tag=hostpinnacle-migrations`. Optional: run in package service provider if config says `hostpinnacle.saas.enabled` or similar.
 
 **4.5 Model: `HostpinnacleAccount`**
 
 - **Location:** `src/Models/HostpinnacleAccount.php` (or `src/HostpinnacleAccount.php`).
-- **Relations:** BelongsTo user (or polymorphic “accountable”) as per migration. Relationship name configurable via config (e.g. `hostpinnacle.saas.owner_relation`).
-- **Credentials:** Method `toCredentials(): HostpinnacleCredentials` that returns a value object from the model’s attributes (and decrypts password if needed).
+- **Relations:** BelongsTo user (or polymorphic "accountable") as per migration. Relationship name configurable via config (e.g. `hostpinnacle.saas.owner_relation`).
+- **Credentials:** Method `toCredentials(): HostpinnacleCredentials` that returns a value object from the model's attributes (and decrypts password if needed).
 - **Security:** Use `encrypted` cast for `password` (and optionally `api_key`) so DB stores encrypted values.
 - **Config:** Config key, e.g. `hostpinnacle.saas.owner_key` (`user_id` vs `tenant_id` vs polymorphic) so the app can adapt without code change.
 
@@ -126,17 +126,17 @@ Credentials are therefore **global and fixed** per app instance. To support SaaS
 
 - **File:** `config/hostpinnacle.php` (extend published config).
 - **New keys (suggestion):**
-  - `hostpinnacle.saas.enabled` (bool) — turn on SaaS features (migrations, routes, “for account” API).
+  - `hostpinnacle.saas.enabled` (bool) — turn on SaaS features (migrations, routes, "for account" API).
   - `hostpinnacle.saas.owner_type` — e.g. `user` (then we use `user_id`), or `tenant`, or `polymorphic`.
   - `hostpinnacle.saas.table` — table name, default `hostpinnacle_accounts`.
   - `hostpinnacle.saas.encrypt_password` (bool) — whether to encrypt password in DB.
   - **Routes:** `saas.api_routes_enabled` (bool), `saas.web_routes_enabled` (bool); optional `saas.api_prefix`, `saas.web_prefix`, `saas.api_middleware`, `saas.web_middleware` so implementers can use API only, Web only, or both (e.g. API for SPAs, Web for Laravel with inbuilt Vue).
 
-This keeps the package usable for different SaaS shapes (per-user, per-tenant, etc.) without hardcoding “User” in the package.
+This keeps the package usable for different SaaS shapes (per-user, per-tenant, etc.) without hardcoding "User" in the package.
 
 ---
 
-### Phase 3: Resolver / factory for “send as this account”
+### Phase 3: Resolver / factory for "send as this account"
 
 **4.7 Factory or static helper**
 
@@ -160,7 +160,7 @@ This keeps the package usable for different SaaS shapes (per-user, per-tenant, e
 **4.9 Controller and shared logic**
 
 - **Scope:** The package provides **both API and Web routes** for CRUD of Hostpinnacle accounts. No UI is shipped; implementers build their own (Blade, Vue, SPA, mobile, etc.) and call either the API or the web endpoints.
-- **Controller:** e.g. `HostpinnacleAccountController` — `index`, `store`, `update`, `destroy` (and optionally `show`). Resolve “current owner” from config (e.g. `auth()->user()->id`). Validate input (required fields, format). Use policy or middleware so only the owner can manage their accounts.
+- **Controller:** e.g. `HostpinnacleAccountController` — `index`, `store`, `update`, `destroy` (and optionally `show`). Resolve "current owner" from config (e.g. `auth()->user()->id`). Validate input (required fields, format). Use policy or middleware so only the owner can manage their accounts.
 - **Response format (single controller for both):**
   - When the request expects JSON (`Accept: application/json` or `request()->wantsJson()`): always return JSON (resource or array). Used by API routes and by AJAX calls from Vue/Blade (e.g. axios with `Accept: application/json`).
   - When the request is a normal web request (e.g. form POST from Blade): return `redirect()->back()->with('success', ...)` or `redirect()->route(...)` and use session flash for errors. So Laravel apps with inbuilt Vue can use classic forms that post to web routes and get redirects, or Vue components that call the same web routes and get JSON.
@@ -184,7 +184,7 @@ This keeps the package usable for different SaaS shapes (per-user, per-tenant, e
 
 **4.13 Example UI (optional, out of scope for initial release)**
 
-- The package **does not** ship production UI. If desired later, *example* views (e.g. simple Blade forms or Vue components) could be provided as a **reference only** — e.g. in a separate repo or as publishable “example” stubs (e.g. `hostpinnacle-example-views`) so implementers know they are optional. This keeps the core package lean and UI-agnostic.
+- The package **does not** ship production UI. If desired later, *example* views (e.g. simple Blade forms or Vue components) could be provided as a **reference only** — e.g. in a separate repo or as publishable "example" stubs (e.g. `hostpinnacle-example-views`) so implementers know they are optional. This keeps the core package lean and UI-agnostic.
 
 ---
 
@@ -192,24 +192,24 @@ This keeps the package usable for different SaaS shapes (per-user, per-tenant, e
 
 **4.14 README / docs**
 
-- **Single-account (existing):** Keep current “Configurations” and “Usage” (env vars, `Hostpinnacle::sendQuickSMS(...)`). State that this is unchanged.
+- **Single-account (existing):** Keep current "Configurations" and "Usage" (env vars, `Hostpinnacle::sendQuickSMS(...)`). State that this is unchanged.
 - **SaaS / multi-account:** New section:
   - Enable SaaS in config.
   - Run migration (`hostpinnacle_accounts`).
   - **API routes:** Use for SPAs, mobile, or Vue/React calling the API (JSON). Enable with `saas.api_routes_enabled`.
   - **Web routes:** Use for Laravel with inbuilt Vue/Blade (form posts → redirects, or AJAX with `Accept: application/json` → JSON). Enable with `saas.web_routes_enabled`. Ideal for non-API settings (session auth, Blade + Vue).
-  - Use the package’s API or Web routes (or the model directly) for CRUD; build your own UI.
+  - Use the package's API or Web routes (or the model directly) for CRUD; build your own UI.
   - Resolve account (e.g. from current user) and call `Hostpinnacle::for($account)->sendQuickSMS(...)`.
-  - Example: “Resolving account for current user” (e.g. `auth()->user()->hostpinnacleAccount` or `HostpinnacleAccount::forUser(auth()->id())->first()`).
+  - Example: "Resolving account for current user" (e.g. `auth()->user()->hostpinnacleAccount` or `HostpinnacleAccount::forUser(auth()->id())->first()`).
 - **Security:** Recommend HTTPS, encrypted storage for password (and optionally api_key), and not logging credentials.
 
 **4.15 Backward compatibility checklist**
 
 - [x] Existing app with only env set and no new config keys: no errors; same behaviour as today.
 - [x] `new Hostpinnacle()` with no args: uses Config (env).
-- [x] `Hostpinnacle::sendQuickSMS(...)` (facade, no “for”): uses default binding (env).
+- [x] `Hostpinnacle::sendQuickSMS(...)` (facade, no "for"): uses default binding (env).
 - [x] No new required env vars; no required new tables unless the app opts in to SaaS.
-- [x] All existing tests pass; new tests for credentials object and “for account” path.
+- [x] All existing tests pass; new tests for credentials object and "for account" path.
 
 ---
 
@@ -232,7 +232,7 @@ This keeps the package usable for different SaaS shapes (per-user, per-tenant, e
 
 ## 6. Suggested Implementation Order
 
-1. **Phase 1:** Credentials object + refactor `Hostpinnacle` constructor + tests. No new config keys or DB. Ensures zero breakage and sets the base for “per-account” usage.
+1. **Phase 1:** Credentials object + refactor `Hostpinnacle` constructor + tests. No new config keys or DB. Ensures zero breakage and sets the base for "per-account" usage.
 2. **Phase 2:** Config additions, migration, `HostpinnacleAccount` model, `toCredentials()`.
 3. **Phase 3:** Factory + `Hostpinnacle::for($account)` (or equivalent) and a minimal test sending SMS with a stored account.
 4. **Phase 4:** Controller (shared logic), **API routes** and **Web routes** for account CRUD, API resources; gate behind config (api_routes_enabled, web_routes_enabled). No UI in package.
@@ -244,7 +244,7 @@ This keeps the package usable for different SaaS shapes (per-user, per-tenant, e
 
 - **Passwords (and optionally API keys)** in `hostpinnacle_accounts`: store encrypted (Laravel `encrypted` cast or `Crypt::encryptString`). Decrypt only when building `HostpinnacleCredentials` for sending.
 - **API:** Validate and sanitise all inputs; use Laravel validation rules. Never expose raw credentials in API responses (e.g. mask `api_key` in index/show, omit password).
-- **Authorization:** Only the “owner” (user/tenant) of an account can update or delete it; enforce in controller and, if applicable, policy.
+- **Authorization:** Only the "owner" (user/tenant) of an account can update or delete it; enforce in controller and, if applicable, policy.
 - **HTTPS:** Document that production should use HTTPS so credentials are not sent in clear text.
 
 ---

--- a/docs/contributing/implementation-outline.md
+++ b/docs/contributing/implementation-outline.md
@@ -17,7 +17,7 @@ Optionally, example views can be provided later as a reference only.
 | Component | Behaviour |
 |-----------|-----------|
 | **Config** (`config/hostpinnacle.php`) | Reads `apiKey`, `senderId`, `username`, `password`, `baseUrl` from env. |
-| **Hostpinnacle class** | Constructor calls `setApiKey()`, `setBaseUrl()`, `setSenderId()`, `setUsername()`, `setPassword()` which all use `Config::get('hostpinnacle.*')`. No way to inject credentials. |
+| **Hostpinnacle class** | Constructor accepts optional `HostpinnacleCredentials`; when null, uses `HostpinnacleCredentials::fromConfig()`. Credentials are set only in the constructor (no public setters). |
 | **Service provider** | Binds `'laravel-hostpinnacle'` → `new Hostpinnacle()` (no args). |
 | **Facade** | `Hostpinnacle` facade resolves to `'hostpinnacle'` (note: provider binds `'laravel-hostpinnacle'`; alignment should be verified). |
 | **SMS methods** | All use `$this->apiKey`, `$this->baseUrl`, `$this->username`, `$this->password`, `$this->senderId` (from constructor). |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,33 @@
+# Configuration
+
+## Publish config
+
+After installing, publish the `hostpinnacle.php` config file:
+
+```bash
+php artisan hostpinnacle:install
+```
+
+Or via vendor publish:
+
+```bash
+php artisan vendor:publish
+```
+
+Then select the Hostpinnacle config (or use `--tag=hostpinnacle-config`).
+
+## Environment variables
+
+Add and define the following in your `.env` file:
+
+```env
+HOSTPINNACLE_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxx
+HOSTPINNACLE_SENDER_ID=xxxxxxxxxx
+HOSTPINNACLE_LOGIN_USERNAME=xxxxxxxxxxxxxxx
+HOSTPINNACLE_LOGIN_PASSWORD=xxxxxx
+HOSTPINNACLE_BASE_URL=https://smsportal.hostpinnacle.co.ke/SMSApi
+```
+
+These are used for **single-account** mode (one set of credentials app-wide). For **SaaS multi-account**, see [SaaS / Multi-Account](/guide/saas-multi-account).
+
+For full config options (including SaaS), see [Config reference](/reference/config).

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,0 +1,24 @@
+# Installation
+
+Install the Laravel Hostpinnacle package via Composer:
+
+```bash
+composer require itsmurumba/laravel-hostpinnacle
+```
+
+## Laravel 5.5+
+
+Package auto-discovery registers the service provider. Skip to [Configuration](/guide/configuration).
+
+## Laravel 5.4 and below
+
+Register the service provider and (optional) alias in `config/app.php`:
+
+```php
+'providers' => [
+    // ...
+    Itsmurumba\Hostpinnacle\HostpinnacleServiceProvider::class,
+],
+```
+
+Next: [Configuration](/guide/configuration) to publish config and set env variables.

--- a/docs/guide/saas-multi-account.md
+++ b/docs/guide/saas-multi-account.md
@@ -14,7 +14,7 @@ If you run a SaaS where each customer has their own Hostpinnacle account, you ca
    ```
 
    ::: warning Migration and config
-   The migration uses `saas.table` and `saas.owner_key` from config to create the table and owner column. **Set these values before running the migration.** Do not change `saas.table` or `saas.owner_key` after the migration has run—the model and database would no longer match, and you would need a new migration to rename the table/column.
+   The migration uses `saas.table`, `saas.owner_key` and `saas.owner_key_type` from config to create the table and owner column. **Set these values before running the migration.** Use `owner_key_type` = `uuid` or `string` if your owner model (e.g. User) has a UUID or string primary key. Do not change these after the migration has run—the model and database would no longer match, and you would need a new migration to alter the table.
    :::
 
 3. **Routes (optional):** The package registers **API** and **Web** routes for CRUD on Hostpinnacle accounts when SaaS is enabled. You can turn them on/off in config:
@@ -45,7 +45,7 @@ See [Config reference](/reference/config) for the full list. Key options:
 |-----|-------------|
 | `saas.enabled` | Turn on multi-account features (migrations, routes, `Hostpinnacle::for()`). |
 | `saas.table` | Table name for accounts (default: `hostpinnacle_accounts`). |
-| `saas.owner_type` / `saas.owner_key` / `saas.owner_model` | Owner of an account (e.g. `user`, `user_id`, `App\Models\User`). |
+| `saas.owner_type` / `saas.owner_key` / `saas.owner_key_type` / `saas.owner_model` | Owner of an account; set `owner_key_type` to `uuid` or `string` when the owner model uses a non-integer primary key. |
 | `saas.encrypt_password` | Encrypt password in DB (default: true). |
 | `saas.api_routes_enabled` / `saas.web_routes_enabled` | Enable API and/or Web CRUD routes. |
 | `saas.api_prefix` / `saas.web_prefix` | Route prefixes (e.g. `api`, `hostpinnacle`). |

--- a/docs/guide/saas-multi-account.md
+++ b/docs/guide/saas-multi-account.md
@@ -13,6 +13,10 @@ If you run a SaaS where each customer has their own Hostpinnacle account, you ca
    php artisan migrate
    ```
 
+   ::: warning Migration and config
+   The migration uses `saas.table` and `saas.owner_key` from config to create the table and owner column. **Set these values before running the migration.** Do not change `saas.table` or `saas.owner_key` after the migration has run—the model and database would no longer match, and you would need a new migration to rename the table/column.
+   :::
+
 3. **Routes (optional):** The package registers **API** and **Web** routes for CRUD on Hostpinnacle accounts when SaaS is enabled. You can turn them on/off in config:
    - **API routes** — JSON; for SPAs, mobile apps, or Vue/React calling the API (e.g. `api/hostpinnacle/accounts`). Use `saas.api_routes_enabled` and middleware such as `auth:sanctum`.
    - **Web routes** — same CRUD under `web` + `auth`; support form submissions (redirect + flash) or AJAX with `Accept: application/json`. Use `saas.web_routes_enabled`. Path prefix defaults to `hostpinnacle` (e.g. `hostpinnacle/accounts`).
@@ -50,5 +54,5 @@ See [Config reference](/reference/config) for the full list. Key options:
 ## Security (SaaS)
 
 - Use **HTTPS** in production so credentials are not sent in clear text.
-- Passwords (and optionally API keys) are stored encrypted when `saas.encrypt_password` is true.
+- Passwords are stored encrypted when `saas.encrypt_password` is true.
 - Do not log credentials; the package masks `api_key` in API responses and never returns `password`.

--- a/docs/guide/saas-multi-account.md
+++ b/docs/guide/saas-multi-account.md
@@ -1,0 +1,54 @@
+# SaaS / Multi-Account
+
+If you run a SaaS where each customer has their own Hostpinnacle account, you can enable **multi-account** mode. Each tenant/user stores their own credentials in the database and sends SMS using their account. Single-account usage is unchanged.
+
+## Enable SaaS
+
+1. **Config:** In `config/hostpinnacle.php`, set `saas.enabled` to `true` (or set `HOSTPINNACLE_SAAS_ENABLED=true` in `.env`).
+
+2. **Migration:** Publish and run the accounts table:
+
+   ```bash
+   php artisan vendor:publish --tag=hostpinnacle-migrations
+   php artisan migrate
+   ```
+
+3. **Routes (optional):** The package registers **API** and **Web** routes for CRUD on Hostpinnacle accounts when SaaS is enabled. You can turn them on/off in config:
+   - **API routes** — JSON; for SPAs, mobile apps, or Vue/React calling the API (e.g. `api/hostpinnacle/accounts`). Use `saas.api_routes_enabled` and middleware such as `auth:sanctum`.
+   - **Web routes** — same CRUD under `web` + `auth`; support form submissions (redirect + flash) or AJAX with `Accept: application/json`. Use `saas.web_routes_enabled`. Path prefix defaults to `hostpinnacle` (e.g. `hostpinnacle/accounts`).
+
+   Build your own UI (Blade, Vue, SPA, etc.) and call these endpoints or use the `HostpinnacleAccount` model directly.
+
+## Sending SMS as a stored account
+
+Resolve the account (e.g. for the current user or tenant), then use the facade:
+
+```php
+use Itsmurumba\Hostpinnacle\Facades\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
+
+$account = HostpinnacleAccount::where('user_id', auth()->id())->first(); // or your owner key
+$response = Hostpinnacle::for($account)->sendQuickSMS(['mobile' => '254720xxxxxx', 'msg' => 'Hello!']);
+```
+
+You can also pass `HostpinnacleCredentials` to `Hostpinnacle::for($credentials)` if you have a value object instead of a model.
+
+## Config options (SaaS)
+
+See [Config reference](/reference/config) for the full list. Key options:
+
+| Key | Description |
+|-----|-------------|
+| `saas.enabled` | Turn on multi-account features (migrations, routes, `Hostpinnacle::for()`). |
+| `saas.table` | Table name for accounts (default: `hostpinnacle_accounts`). |
+| `saas.owner_type` / `saas.owner_key` / `saas.owner_model` | Owner of an account (e.g. `user`, `user_id`, `App\Models\User`). |
+| `saas.encrypt_password` | Encrypt password in DB (default: true). |
+| `saas.api_routes_enabled` / `saas.web_routes_enabled` | Enable API and/or Web CRUD routes. |
+| `saas.api_prefix` / `saas.web_prefix` | Route prefixes (e.g. `api`, `hostpinnacle`). |
+| `saas.api_middleware` / `saas.web_middleware` | Middleware for API and Web routes. |
+
+## Security (SaaS)
+
+- Use **HTTPS** in production so credentials are not sent in clear text.
+- Passwords (and optionally API keys) are stored encrypted when `saas.encrypt_password` is true.
+- Do not log credentials; the package masks `api_key` in API responses and never returns `password`.

--- a/docs/guide/testing-locally-before-publish.md
+++ b/docs/guide/testing-locally-before-publish.md
@@ -1,0 +1,82 @@
+# Testing the package locally (before publishing)
+
+You can use the package in a real Laravel application without publishing it to Packagist. Two common approaches:
+
+## 1. Path repository (recommended)
+
+Use the package from your filesystem so you can edit the package code and see changes in the app immediately.
+
+1. **Create or use an existing Laravel app** (e.g. `my-laravel-app`).
+
+2. **Add a path repository** in the app’s `composer.json`:
+
+```json
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../laravel-hostpinnacle"
+        }
+    ],
+    "require": {
+        "itsmurumba/laravel-hostpinnacle": "@dev"
+    }
+}
+```
+
+Adjust `url` to the actual path to your package (absolute or relative to the app).
+
+3. **Install/update** from the app directory:
+
+```bash
+cd my-laravel-app
+composer update itsmurumba/laravel-hostpinnacle
+```
+
+4. **Configure and use** the package as usual:
+
+- Add Hostpinnacle env vars to `.env`
+- Run `php artisan hostpinnacle:install` if you want to publish config
+- Use the facade or class in controllers, jobs, etc.
+
+Composer will symlink the package, so changes in `laravel-hostpinnacle` are reflected in the app without running `composer update` again.
+
+## 2. From a Git branch (VCS)
+
+Test the package as it would be installed from GitHub (e.g. to verify `composer.json` and the repository before a public release).
+
+1. **Push your branch** to GitHub (e.g. `feature/saas-multi-account` or `main`).
+
+2. **In your Laravel app’s `composer.json`** add the VCS repo and require the branch:
+
+```json
+{
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ItsMurumba/laravel-hostpinnacle"
+        }
+    ],
+    "require": {
+        "itsmurumba/laravel-hostpinnacle": "dev-feature/saas-multi-account"
+    }
+}
+```
+
+Replace `dev-feature/saas-multi-account` with your branch name (Composer uses `dev-<branch>` for non-stable branches).
+
+3. **Install/update** from the app directory:
+
+```bash
+composer update itsmurumba/laravel-hostpinnacle
+```
+
+4. **Configure and test** the app. To pick up package changes, push to the branch and run `composer update itsmurumba/laravel-hostpinnacle` again.
+
+## What to test
+
+- **Single-account:** Set env vars, send Quick SMS, Group SMS, or File Upload via the facade or `new Hostpinnacle()`.
+- **SaaS:** Set `HOSTPINNACLE_SAAS_ENABLED=true`, run migrations, register/auth a user, create an account via API or web routes, then `Hostpinnacle::for($account)->sendQuickSMS(...)`.
+- **Artisan:** `php artisan hostpinnacle:install` and overwrite behaviour when config exists.
+
+Once everything works, you can tag a release and publish to Packagist.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,0 +1,45 @@
+# Testing
+
+Tests use **[Pest](https://pestphp.com/)** (PHP testing framework) and **[Orchestra Testbench](https://orchestraplatform.com/docs/testbench)** for Laravel package testing.
+
+## Run tests
+
+```bash
+composer test
+```
+
+Or directly with Pest:
+
+```bash
+vendor/bin/pest
+```
+
+## Code coverage
+
+Code coverage (optional) requires a coverage driver: **PCOV** or **Xdebug**. Without one, `composer test:coverage` will report "No code coverage driver is available".
+
+- **PCOV** (line coverage, fast):
+  - **macOS (Homebrew):** `brew tap shivammathur/extensions && brew install pcov@8.3` (use your PHP version, e.g. `pcov@8.3`). Then run coverage with that PHP: `PATH="/opt/homebrew/opt/php/bin:$PATH" composer test:coverage`.
+  - **PECL:** `pecl install pcov` then add `extension=pcov.so` to your `php.ini`.
+- **Xdebug** (full metrics): install Xdebug and enable [coverage mode](https://xdebug.org/docs/code_coverage#mode).
+
+If you use **Laravel Herd**, either enable PCOV or Xdebug in Herd’s PHP settings, or run coverage with a PHP that has PCOV (e.g. Homebrew as above).
+
+Then run:
+
+```bash
+composer test:coverage
+```
+
+Or with Pest:
+
+```bash
+vendor/bin/pest --coverage
+```
+
+Coverage is reported in the terminal and written to:
+
+- **HTML:** `build/coverage/index.html` (open in a browser)
+- **Clover XML:** `build/coverage/clover.xml` (for CI tools)
+
+The `build/` directory is gitignored. The `test:coverage` script creates `build/coverage` automatically.

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -1,0 +1,98 @@
+# Usage
+
+Single-account usage: one set of credentials from config/env, used app-wide.
+
+## Using the class
+
+Inject or instantiate the `Hostpinnacle` class:
+
+```php
+protected $hostpinnacle;
+
+public function __construct()
+{
+    $this->hostpinnacle = new Hostpinnacle();
+}
+```
+
+## Using the facade
+
+```php
+use Itsmurumba\Hostpinnacle\Facades\Hostpinnacle;
+
+$response = Hostpinnacle::sendQuickSMS(['mobile' => '254720xxxxxx', 'msg' => 'Hello World!']);
+```
+
+## 1. Quick SMS
+
+**Send quick SMS (batch):**
+
+```php
+$data['mobile'] = '254720xxxxxx';
+$data['msg'] = 'Hello World!';
+$response = $this->hostpinnacle->sendQuickSMS($data);
+```
+
+**Send quick scheduled SMS:**
+
+```php
+$data['scheduledTime'] = '2023-02-28 17:32:03';
+$data['mobile'] = '254720xxxxxx';
+$data['msg'] = 'Hello World!';
+$response = $this->hostpinnacle->sendQuickScheduledSMS($data);
+```
+
+## 2. Group SMS
+
+**Send group SMS:**
+
+```php
+$data['groupIds'] = '1056';
+$data['msg'] = 'Hello World!';
+$response = $this->hostpinnacle->sendGroupSMS($data);
+```
+
+**Send group scheduled SMS:**
+
+```php
+$data['scheduledTime'] = '2023-02-28 17:32:03';
+$data['groupIds'] = '1056';
+$data['msg'] = 'Hello World!';
+$response = $this->hostpinnacle->sendGroupScheduledSMS($data);
+```
+
+## 3. File Upload SMS
+
+**Mobile numbers only (message in code):**
+
+```php
+$data['file'] = $request->file('file');
+$data['msg'] = 'Hello World!';
+$response = $this->hostpinnacle->sendMobileOnlyFileSMS($data);
+```
+
+**Mobile numbers only, scheduled:**
+
+```php
+$data['scheduledTime'] = '2023-02-28 17:32:03';
+$data['file'] = $request->file('file');
+$data['msg'] = 'Hello World!';
+$response = $this->hostpinnacle->sendMobileOnlyFileScheduledSMS($data);
+```
+
+**File with mobile numbers and message in file:**
+
+```php
+$data['file'] = $request->file('file');
+$response = $this->hostpinnacle->sendMobileAndMessageFileSMS($data);
+```
+
+**File with mobile and message, scheduled:**
+
+```php
+$data['scheduledTime'] = '2023-02-28 17:32:03';
+$data['file'] = $request->file('file');
+$response = $this->hostpinnacle->sendMobileAndMessageFileScheduledSMS($data);
+```
+
+All methods return an `Illuminate\Http\Client\Response`; use `$response->successful()` or `$response->json()` as needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+# Laravel Hostpinnacle
+
+Official Laravel package for the **Hostpinnacle SMS API**. It supports all public endpoints:
+
+- **Quick SMS** — single and batch, with optional scheduling
+- **Group SMS** — send to groups, with optional scheduling
+- **File Upload** — SMS from file (mobile-only or mobile + message)
+
+Use one set of credentials from env (single-account) or enable **SaaS multi-account** so each tenant stores their own credentials and sends via `Hostpinnacle::for($account)`.
+
+## Quick start
+
+```bash
+composer require itsmurumba/laravel-hostpinnacle
+```
+
+```bash
+php artisan hostpinnacle:install
+```
+
+Add your credentials to `.env`, then send SMS:
+
+```php
+use Itsmurumba\Hostpinnacle\Facades\Hostpinnacle;
+
+$response = Hostpinnacle::sendQuickSMS([
+    'mobile' => '254720xxxxxx',
+    'msg' => 'Hello World!',
+]);
+```
+
+## Documentation
+
+- **[Installation](/guide/installation)** — Install the package and publish config
+- **[Configuration](/guide/configuration)** — Env variables and config file
+- **[Usage](/guide/usage)** — Quick SMS, Group SMS, File Upload (single-account)
+- **[SaaS / Multi-Account](/guide/saas-multi-account)** — Per-tenant credentials and routes
+- **[Testing](/guide/testing)** — Running tests and code coverage
+
+## Links
+
+- [GitHub](https://github.com/ItsMurumba/laravel-hostpinnacle)
+- [Contribution guidelines](https://github.com/ItsMurumba/laravel-hostpinnacle/blob/main/Contribution.md)

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -14,8 +14,8 @@
 
 ## SaaS (`saas` array)
 
-::: warning Table and owner key
-`table` and `owner_key` are used by the published migration. Set them before running `php artisan migrate`. Do not change them after the migration has run, or the model will expect a different table/column than exists in the database.
+::: warning Table and owner column
+`table`, `owner_key` and `owner_key_type` are used by the published migration. Set them before running `php artisan migrate`. Do not change them after the migration has run, or the model will expect a different table/column than exists in the database.
 :::
 
 | Key | Env | Default | Description |
@@ -24,6 +24,7 @@
 | `table` | — | `hostpinnacle_accounts` | Table name for stored accounts (set before migrating; do not change after) |
 | `owner_type` | `HOSTPINNACLE_SAAS_OWNER_TYPE` | `user` | Owner type (e.g. user, tenant) |
 | `owner_key` | `HOSTPINNACLE_SAAS_OWNER_KEY` | `user_id` | Owner foreign key column name (set before migrating; do not change after) |
+| `owner_key_type` | `HOSTPINNACLE_SAAS_OWNER_KEY_TYPE` | `unsignedBigInteger` | Owner column type: `unsignedBigInteger`, `uuid`, or `string` (set before migrating; use `uuid` or `string` when owner model has UUID/string PK) |
 | `owner_model` | `HOSTPINNACLE_SAAS_OWNER_MODEL` | `App\Models\User` | Eloquent model for owner relation |
 | `encrypt_password` | `HOSTPINNACLE_SAAS_ENCRYPT_PASSWORD` | `true` | Encrypt password in DB |
 | `api_routes_enabled` | `HOSTPINNACLE_SAAS_API_ROUTES_ENABLED` | `true` | Register API CRUD routes when SaaS enabled |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,30 @@
+# Config reference
+
+`config/hostpinnacle.php` (published via `php artisan hostpinnacle:install` or `vendor:publish --tag=hostpinnacle-config`).
+
+## Single-account (env)
+
+| Key | Env | Description |
+|-----|-----|-------------|
+| `apiKey` | `HOSTPINNACLE_API_KEY` | API key from Hostpinnacle Portal |
+| `senderId` | `HOSTPINNACLE_SENDER_ID` | Sender ID from Hostpinnacle Portal |
+| `username` | `HOSTPINNACLE_LOGIN_USERNAME` | Username for Hostpinnacle Portal |
+| `password` | `HOSTPINNACLE_LOGIN_PASSWORD` | Password for Hostpinnacle Portal |
+| `baseUrl` | `HOSTPINNACLE_BASE_URL` | Base URL for Hostpinnacle API |
+
+## SaaS (`saas` array)
+
+| Key | Env | Default | Description |
+|-----|-----|---------|-------------|
+| `enabled` | `HOSTPINNACLE_SAAS_ENABLED` | `false` | Turn on multi-account (migrations, routes, `Hostpinnacle::for()`) |
+| `table` | — | `hostpinnacle_accounts` | Table name for stored accounts |
+| `owner_type` | `HOSTPINNACLE_SAAS_OWNER_TYPE` | `user` | Owner type (e.g. user, tenant) |
+| `owner_key` | `HOSTPINNACLE_SAAS_OWNER_KEY` | `user_id` | Owner foreign key column name |
+| `owner_model` | `HOSTPINNACLE_SAAS_OWNER_MODEL` | `App\Models\User` | Eloquent model for owner relation |
+| `encrypt_password` | `HOSTPINNACLE_SAAS_ENCRYPT_PASSWORD` | `true` | Encrypt password in DB |
+| `api_routes_enabled` | `HOSTPINNACLE_SAAS_API_ROUTES_ENABLED` | `true` | Register API CRUD routes when SaaS enabled |
+| `web_routes_enabled` | `HOSTPINNACLE_SAAS_WEB_ROUTES_ENABLED` | `true` | Register Web CRUD routes when SaaS enabled |
+| `api_prefix` | `HOSTPINNACLE_SAAS_API_PREFIX` | `api` | API route prefix |
+| `web_prefix` | `HOSTPINNACLE_SAAS_WEB_PREFIX` | `hostpinnacle` | Web route path prefix |
+| `api_middleware` | — | `['api', 'auth:sanctum']` | Middleware for API routes |
+| `web_middleware` | — | `['web', 'auth']` | Middleware for Web routes |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -14,12 +14,16 @@
 
 ## SaaS (`saas` array)
 
+::: warning Table and owner key
+`table` and `owner_key` are used by the published migration. Set them before running `php artisan migrate`. Do not change them after the migration has run, or the model will expect a different table/column than exists in the database.
+:::
+
 | Key | Env | Default | Description |
 |-----|-----|---------|-------------|
 | `enabled` | `HOSTPINNACLE_SAAS_ENABLED` | `false` | Turn on multi-account (migrations, routes, `Hostpinnacle::for()`) |
-| `table` | — | `hostpinnacle_accounts` | Table name for stored accounts |
+| `table` | — | `hostpinnacle_accounts` | Table name for stored accounts (set before migrating; do not change after) |
 | `owner_type` | `HOSTPINNACLE_SAAS_OWNER_TYPE` | `user` | Owner type (e.g. user, tenant) |
-| `owner_key` | `HOSTPINNACLE_SAAS_OWNER_KEY` | `user_id` | Owner foreign key column name |
+| `owner_key` | `HOSTPINNACLE_SAAS_OWNER_KEY` | `user_id` | Owner foreign key column name (set before migrating; do not change after) |
 | `owner_model` | `HOSTPINNACLE_SAAS_OWNER_MODEL` | `App\Models\User` | Eloquent model for owner relation |
 | `encrypt_password` | `HOSTPINNACLE_SAAS_ENCRYPT_PASSWORD` | `true` | Encrypt password in DB |
 | `api_routes_enabled` | `HOSTPINNACLE_SAAS_API_ROUTES_ENABLED` | `true` | Register API CRUD routes when SaaS enabled |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2511 @@
+{
+  "name": "laravel-hostpinnacle-docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "laravel-hostpinnacle-docs",
+      "devDependencies": {
+        "vitepress": "^1.6.4"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.13.0.tgz",
+      "integrity": "sha512-Zrqam12iorp3FjiKMXSTpedGYznZ3hTEOAr2oCxI8tbF8bS1kQHClyDYNq/eV0ewMNLyFkgZVWjaS+8spsOYiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.47.0.tgz",
+      "integrity": "sha512-aOpsdlgS9xTEvz47+nXmw8m0NtUiQbvGWNuSEb7fA46iPL5FxOmOUZkh8PREBJpZ0/H8fclSc7BMJCVr+Dn72w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.47.0.tgz",
+      "integrity": "sha512-EcF4w7IvIk1sowrO7Pdy4Ako7x/S8+nuCgdk6En+u5jsaNQM4rTT09zjBPA+WQphXkA2mLrsMwge96rf6i7Mow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.47.0.tgz",
+      "integrity": "sha512-Wzg5Me2FqgRDj0lFuPWFK05UOWccSMsIBL2YqmTmaOzxVlLZ+oUqvKbsUSOE5ud8Fo1JU7JyiLmEXBtgDKzTwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.47.0.tgz",
+      "integrity": "sha512-Ci+cn/FDIsDxSKMRBEiyKrqybblbk8xugo6ujDN1GSTv9RIZxwxqZYuHfdLnLEwLlX7GB8pqVyqrUSlRnR+sJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.47.0.tgz",
+      "integrity": "sha512-gsLnHPZmWcX0T3IigkDL2imCNtsQ7dR5xfnwiFsb+uTHCuYQt+IwSNjsd8tok6HLGLzZrliSaXtB5mfGBtYZvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.47.0.tgz",
+      "integrity": "sha512-PDOw0s8WSlR2fWFjPQldEpmm/gAoUgLigvC3k/jCSi/DzigdGX6RdC0Gh1RR1P8Cbk5KOWYDuL3TNzdYwkfDyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.47.0.tgz",
+      "integrity": "sha512-b5hlU69CuhnS2Rqgsz7uSW0t4VqrLMLTPbUpEl0QVz56rsSwr1Sugyogrjb493sWDA+XU1FU5m9eB8uH7MoI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.47.0.tgz",
+      "integrity": "sha512-WvwwXp5+LqIGISK3zHRApLT1xkuEk320/EGeD7uYy+K8WwDd5OjXnhjuXRhYr1685KnkvWkq1rQ/ihCJjOfHpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.47.0.tgz",
+      "integrity": "sha512-j2EUFKAlzM0TE4GRfkDE3IDfkVeJdcbBANWzK16Tb3RHz87WuDfQ9oeEW6XiRE1/bEkq2xf4MvZesvSeQrZRDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.47.0.tgz",
+      "integrity": "sha512-+kTSE4aQ1ARj2feXyN+DMq0CIDHJwZw1kpxIunedkmpWUg8k3TzFwWsMCzJVkF2nu1UcFbl7xsIURz3Q3XwOXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.47.0.tgz",
+      "integrity": "sha512-Ja+zPoeSA2SDowPwCNRbm5Q2mzDvVV8oqxCQ4m6SNmbKmPlCfe30zPfrt9ho3kBHnsg37pGucwOedRIOIklCHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.47.0.tgz",
+      "integrity": "sha512-N6nOvLbaR4Ge+oVm7T4W/ea1PqcSbsHR4O58FJ31XtZjFPtOyxmnhgCmGCzP9hsJI6+x0yxJjkW5BMK/XI8OvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.47.0.tgz",
+      "integrity": "sha512-z1oyLq5/UVkohVXNDEY70mJbT/sv/t6HYtCvCwNrOri6pxBJDomP9R83KOlwcat+xqBQEdJHjbrPh36f1avmZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.69",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.69.tgz",
+      "integrity": "sha512-T/rhy5n7pzE0ZOxQVlF68SNPCYYjRBpddjgjrJO5WWVRG8es5BQmvxIE9kKF+t2hhPGvuGQFpXmUyqbOtnxirQ==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.27.tgz",
+      "integrity": "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/shared": "3.5.27",
+        "entities": "^7.0.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.27.tgz",
+      "integrity": "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
+      "integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/compiler-core": "3.5.27",
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/compiler-ssr": "3.5.27",
+        "@vue/shared": "3.5.27",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.27.tgz",
+      "integrity": "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.27.tgz",
+      "integrity": "sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.27.tgz",
+      "integrity": "sha512-fxVuX/fzgzeMPn/CLQecWeDIFNt3gQVhxM0rW02Tvp/YmZfXQgcTXlakq7IMutuZ/+Ogbn+K0oct9J3JZfyk3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.27.tgz",
+      "integrity": "sha512-/QnLslQgYqSJ5aUmb5F0z0caZPGHRB8LEAQ1s81vHFM5CBfnun63rxhvE/scVb/j3TbBuoZwkJyiLCkBluMpeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.27",
+        "@vue/runtime-core": "3.5.27",
+        "@vue/shared": "3.5.27",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.27.tgz",
+      "integrity": "sha512-qOz/5thjeP1vAFc4+BY3Nr6wxyLhpeQgAE/8dDtKo6a6xdk+L4W46HDZgNmLOBUDEkFXV3G7pRiUqxjX0/2zWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.27",
+        "@vue/shared": "3.5.27"
+      },
+      "peerDependencies": {
+        "vue": "3.5.27"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
+      "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.47.0.tgz",
+      "integrity": "sha512-AGtz2U7zOV4DlsuYV84tLp2tBbA7RPtLA44jbVH4TTpDcc1dIWmULjHSsunlhscbzDydnjuFlNhflR3nV4VJaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.13.0",
+        "@algolia/client-abtesting": "5.47.0",
+        "@algolia/client-analytics": "5.47.0",
+        "@algolia/client-common": "5.47.0",
+        "@algolia/client-insights": "5.47.0",
+        "@algolia/client-personalization": "5.47.0",
+        "@algolia/client-query-suggestions": "5.47.0",
+        "@algolia/client-search": "5.47.0",
+        "@algolia/ingestion": "1.47.0",
+        "@algolia/monitoring": "1.47.0",
+        "@algolia/recommend": "5.47.0",
+        "@algolia/requester-browser-xhr": "5.47.0",
+        "@algolia/requester-fetch": "5.47.0",
+        "@algolia/requester-node-http": "5.47.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.28.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
+      "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
+      "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/compiler-sfc": "3.5.27",
+        "@vue/runtime-dom": "3.5.27",
+        "@vue/server-renderer": "3.5.27",
+        "@vue/shared": "3.5.27"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "laravel-hostpinnacle-docs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.4"
+  }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Itsmurumba\Hostpinnacle\Http\Controllers\HostpinnacleAccountController;
+
+/*
+|--------------------------------------------------------------------------
+| Hostpinnacle SaaS API Routes
+|--------------------------------------------------------------------------
+|
+| Only loaded when hostpinnacle.saas.enabled and hostpinnacle.saas.api_routes_enabled are true.
+|
+*/
+
+$prefix = config('hostpinnacle.saas.api_prefix', 'api');
+$path = config('hostpinnacle.saas.web_prefix', 'hostpinnacle') . '/accounts';
+$middleware = config('hostpinnacle.saas.api_middleware', ['api', 'auth:sanctum']);
+
+Route::prefix($prefix)->middleware($middleware)->group(function () use ($path) {
+    Route::apiResource($path, HostpinnacleAccountController::class)->names('hostpinnacle.api.accounts');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Itsmurumba\Hostpinnacle\Http\Controllers\HostpinnacleAccountController;
+
+/*
+|--------------------------------------------------------------------------
+| Hostpinnacle SaaS Web Routes
+|--------------------------------------------------------------------------
+|
+| Only loaded when hostpinnacle.saas.enabled and hostpinnacle.saas.web_routes_enabled are true.
+|
+*/
+
+$prefix = config('hostpinnacle.saas.web_prefix', 'hostpinnacle');
+$middleware = config('hostpinnacle.saas.web_middleware', ['web', 'auth']);
+
+Route::prefix($prefix)->middleware($middleware)->group(function () {
+    Route::resource('accounts', HostpinnacleAccountController::class)->names('hostpinnacle.web.accounts')->except(['create', 'edit']);
+});

--- a/src/Console/InstallHostpinnaclePackage.php
+++ b/src/Console/InstallHostpinnaclePackage.php
@@ -24,9 +24,9 @@ class InstallHostpinnaclePackage extends Command
     public function handle()
     {
         $this->info('Installing Laravel Hostpinnacle......');
-        $this->info('Publishing hostpinnacle configuration');
 
         if (!$this->configExists('hostpinnacle.php')) {
+            $this->info('Publishing hostpinnacle configuration');
             $this->publishConfiguration();
             $this->info('Published hostpinnacle configuration');
         } else {

--- a/src/Console/InstallHostpinnaclePackage.php
+++ b/src/Console/InstallHostpinnaclePackage.php
@@ -28,7 +28,7 @@ class InstallHostpinnaclePackage extends Command
 
         if (!$this->configExists('hostpinnacle.php')) {
             $this->publishConfiguration();
-            $this->info('Publishing hostpinnacle configuration');
+            $this->info('Published hostpinnacle configuration');
         } else {
             if ($this->shouldOverwriteConfig()) {
                 $this->info('Overwriting hostpinnacle configuration file......');

--- a/src/Console/InstallHostpinnaclePackage.php
+++ b/src/Console/InstallHostpinnaclePackage.php
@@ -5,15 +5,25 @@ namespace Itsmurumba\Hostpinnacle\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 
+/**
+ * Artisan command to publish the Hostpinnacle config file.
+ */
 class InstallHostpinnaclePackage extends Command
 {
+    /** @var string */
     protected $signature = 'hostpinnacle:install';
 
+    /** @var string */
     protected $description = 'Install Hostpinnacle Laravel Package';
 
+    /**
+     * Publish config; prompt to overwrite if config already exists.
+     *
+     * @return int
+     */
     public function handle()
     {
-        $this->info('Installing Laravel Mpesa......');
+        $this->info('Installing Laravel Hostpinnacle......');
         $this->info('Publishing hostpinnacle configuration');
 
         if (!$this->configExists('hostpinnacle.php')) {
@@ -21,7 +31,7 @@ class InstallHostpinnaclePackage extends Command
             $this->info('Publishing hostpinnacle configuration');
         } else {
             if ($this->shouldOverwriteConfig()) {
-                $this->info('Overwitting hostpinnacle configuration file......');
+                $this->info('Overwriting hostpinnacle configuration file......');
                 $this->publishConfiguration($force = true);
             } else {
                 $this->info('Exiting. Hostpinnacle configuration was not overwritten');
@@ -29,18 +39,37 @@ class InstallHostpinnaclePackage extends Command
         }
 
         $this->info('Installed Hostpinnacle Package');
+
+        return self::SUCCESS;
     }
 
+    /**
+     * Check if a config file exists in the application config path.
+     *
+     * @param  string  $fileName
+     * @return bool
+     */
     private function configExists($fileName)
     {
         return File::exists(config_path($fileName));
     }
 
+    /**
+     * Ask the user whether to overwrite the existing config file.
+     *
+     * @return bool
+     */
     private function shouldOverwriteConfig()
     {
         return $this->confirm('Config file already exists. Do you want to overwrite it?', false);
     }
 
+    /**
+     * Publish the hostpinnacle config via vendor:publish.
+     *
+     * @param  bool  $forcePublish
+     * @return int
+     */
     private function publishConfiguration($forcePublish = false)
     {
         $params = [
@@ -52,6 +81,6 @@ class InstallHostpinnaclePackage extends Command
             $params['--force'] = true;
         }
 
-        $this->call('vendor:publish', $params);
+        return $this->call('vendor:publish', $params);
     }
 }

--- a/src/Console/InstallHostpinnaclePackage.php
+++ b/src/Console/InstallHostpinnaclePackage.php
@@ -32,7 +32,7 @@ class InstallHostpinnaclePackage extends Command
         } else {
             if ($this->shouldOverwriteConfig()) {
                 $this->info('Overwriting hostpinnacle configuration file......');
-                $this->publishConfiguration($force = true);
+                $this->publishConfiguration(true);
             } else {
                 $this->info('Exiting. Hostpinnacle configuration was not overwritten');
             }

--- a/src/Exceptions/IsNullException.php
+++ b/src/Exceptions/IsNullException.php
@@ -4,6 +4,7 @@ namespace Itsmurumba\Hostpinnacle\Exceptions;
 
 use Exception;
 
-class IsNullException extends Exception
-{
-}
+/**
+ * Exception thrown when a required value is null (e.g. missing msg or mobile for SMS).
+ */
+class IsNullException extends Exception {}

--- a/src/Facades/Hostpinnacle.php
+++ b/src/Facades/Hostpinnacle.php
@@ -8,6 +8,8 @@ use Itsmurumba\Hostpinnacle\HostpinnacleFactory;
 use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
 
 /**
+ * Facade for the Hostpinnacle SMS client. Use for single-account (config) or Hostpinnacle::for($account) for SaaS.
+ *
  * @method static \Illuminate\Http\Client\Response sendQuickSMS(array $data)
  * @method static \Illuminate\Http\Client\Response sendQuickScheduledSMS(array $data)
  * @method static \Illuminate\Http\Client\Response sendGroupSMS(array $data)
@@ -16,12 +18,18 @@ use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
  * @method static \Illuminate\Http\Client\Response sendMobileOnlyFileScheduledSMS(array $data)
  * @method static \Illuminate\Http\Client\Response sendMobileAndMessageFileSMS(array $data)
  * @method static \Illuminate\Http\Client\Response sendMobileAndMessageFileScheduledSMS(array $data)
+ * @method static HostpinnacleClient for(HostpinnacleAccount|\Itsmurumba\Hostpinnacle\HostpinnacleCredentials $accountOrCredentials)
  *
  * @see \Itsmurumba\Hostpinnacle\Hostpinnacle
  * @see \Itsmurumba\Hostpinnacle\HostpinnacleFactory
  */
 class Hostpinnacle extends Facade
 {
+    /**
+     * Get the facade accessor (container key).
+     *
+     * @return string
+     */
     protected static function getFacadeAccessor()
     {
         return 'hostpinnacle';

--- a/src/Facades/Hostpinnacle.php
+++ b/src/Facades/Hostpinnacle.php
@@ -3,11 +3,38 @@
 namespace Itsmurumba\Hostpinnacle\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Itsmurumba\Hostpinnacle\Hostpinnacle as HostpinnacleClient;
+use Itsmurumba\Hostpinnacle\HostpinnacleFactory;
+use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
 
+/**
+ * @method static \Illuminate\Http\Client\Response sendQuickSMS(array $data)
+ * @method static \Illuminate\Http\Client\Response sendQuickScheduledSMS(array $data)
+ * @method static \Illuminate\Http\Client\Response sendGroupSMS(array $data)
+ * @method static \Illuminate\Http\Client\Response sendGroupScheduledSMS(array $data)
+ * @method static \Illuminate\Http\Client\Response sendMobileOnlyFileSMS(array $data)
+ * @method static \Illuminate\Http\Client\Response sendMobileOnlyFileScheduledSMS(array $data)
+ * @method static \Illuminate\Http\Client\Response sendMobileAndMessageFileSMS(array $data)
+ * @method static \Illuminate\Http\Client\Response sendMobileAndMessageFileScheduledSMS(array $data)
+ *
+ * @see \Itsmurumba\Hostpinnacle\Hostpinnacle
+ * @see \Itsmurumba\Hostpinnacle\HostpinnacleFactory
+ */
 class Hostpinnacle extends Facade
 {
     protected static function getFacadeAccessor()
     {
         return 'hostpinnacle';
+    }
+
+    /**
+     * Create a Hostpinnacle instance for the given account or credentials (SaaS multi-account).
+     *
+     * @param  HostpinnacleAccount|\Itsmurumba\Hostpinnacle\HostpinnacleCredentials  $accountOrCredentials
+     * @return HostpinnacleClient
+     */
+    public static function for(HostpinnacleAccount|\Itsmurumba\Hostpinnacle\HostpinnacleCredentials $accountOrCredentials): HostpinnacleClient
+    {
+        return app(HostpinnacleFactory::class)->for($accountOrCredentials);
     }
 }

--- a/src/Hostpinnacle.php
+++ b/src/Hostpinnacle.php
@@ -53,46 +53,6 @@ class Hostpinnacle
     }
 
     /**
-     * Set base URL from config.
-     */
-    public function setBaseUrl(): void
-    {
-        $this->baseUrl = Config::get('hostpinnacle.baseUrl');
-    }
-
-    /**
-     * Set API key from config.
-     */
-    public function setApiKey(): void
-    {
-        $this->apiKey = Config::get('hostpinnacle.apiKey');
-    }
-
-    /**
-     * Set Sender ID from config.
-     */
-    public function setSenderId(): void
-    {
-        $this->senderId = Config::get('hostpinnacle.senderId');
-    }
-
-    /**
-     * Set username from config.
-     */
-    public function setUsername(): void
-    {
-        $this->username = Config::get('hostpinnacle.username');
-    }
-
-    /**
-     * Set password from config.
-     */
-    public function setPassword(): void
-    {
-        $this->password = Config::get('hostpinnacle.password');
-    }
-
-    /**
      * Configure the Guzzle client with base URI and headers.
      */
     private function setRequestOptions(): void

--- a/src/Hostpinnacle.php
+++ b/src/Hostpinnacle.php
@@ -7,47 +7,38 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Config;
 use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
 
+/**
+ * Hostpinnacle SMS API client. Sends Quick SMS, Group SMS, and File Upload SMS.
+ * Uses config (env) when constructed with null; use HostpinnacleCredentials for per-account credentials.
+ */
 class Hostpinnacle
 {
-    /**
-     * Issue API Key from your Hostpinnacle Dashboard
-     * @var string
-     */
+    /** @var string API key from Hostpinnacle Dashboard */
     protected $apiKey;
 
-    /**
-     * Instance of Client
-     * @var Client
-     */
+    /** @var Client Guzzle HTTP client */
     protected $client;
 
-    /**
-     * Response from requests made to Hostpinnacle
-     * @var Mixed
-     */
+    /** @var mixed Last response from the API */
     protected $response;
 
-    /**
-     * Hostpinnacle API base URL
-     * @var string
-     */
+    /** @var string Hostpinnacle API base URL */
     protected $baseUrl;
 
-    /**
-     * Approved SenderId from Hostpinnacle Dashboard
-     */
+    /** @var string Approved Sender ID from Hostpinnacle Dashboard */
     protected $senderId;
 
-    /**
-     * Username for logging into Hostpinnacle Portal
-     */
+    /** @var string Username for Hostpinnacle Portal */
     protected $username;
 
-    /**
-     * Password for logging into Hostpinnacle Portal
-     */
+    /** @var string Password for Hostpinnacle Portal */
     protected $password;
 
+    /**
+     * Create a new Hostpinnacle instance. Uses config when credentials are null.
+     *
+     * @param  \Itsmurumba\Hostpinnacle\HostpinnacleCredentials|null  $credentials
+     */
     public function __construct(?HostpinnacleCredentials $credentials = null)
     {
         $creds = $credentials ?? HostpinnacleCredentials::fromConfig();
@@ -62,51 +53,50 @@ class Hostpinnacle
     }
 
     /**
-     * Get Base URL from Hostpinnacle config file
+     * Set base URL from config.
      */
-    public function setBaseUrl()
+    public function setBaseUrl(): void
     {
         $this->baseUrl = Config::get('hostpinnacle.baseUrl');
     }
 
     /**
-     * Get API Key from Hostpinnacle config file
+     * Set API key from config.
      */
-    public function setApiKey()
+    public function setApiKey(): void
     {
         $this->apiKey = Config::get('hostpinnacle.apiKey');
     }
 
     /**
-     * Get Sender Id from Hostpinnacle config file
+     * Set Sender ID from config.
      */
-    public function setSenderId()
+    public function setSenderId(): void
     {
         $this->senderId = Config::get('hostpinnacle.senderId');
     }
 
     /**
-     * Get Username from Hostpinnacle config file
+     * Set username from config.
      */
-    public function setUsername()
+    public function setUsername(): void
     {
         $this->username = Config::get('hostpinnacle.username');
     }
 
     /**
-     * Get Password from Hostpinnacle config file
+     * Set password from config.
      */
-    public function setPassword()
+    public function setPassword(): void
     {
         $this->password = Config::get('hostpinnacle.password');
     }
 
     /**
-     * Set options for making the Client request
+     * Configure the Guzzle client with base URI and headers.
      */
-    private function setRequestOptions()
+    private function setRequestOptions(): void
     {
-
         $this->client = new Client(
             [
                 'base_uri' => $this->baseUrl,
@@ -120,40 +110,36 @@ class Hostpinnacle
     }
 
     /**
-     * Undocumented function
+     * Send an HTTP request and return the response.
      *
-     * @param [type] $relativeUrl
-     * @param [type] $method
-     * @param array $body
-     * @return void
+     * @param  string  $relativeUrl
+     * @param  string  $method
+     * @param  array<string, mixed>  $body
+     * @return \Psr\Http\Message\ResponseInterface
+     * @throws IsNullException
      */
     private function setHttpResponse($relativeUrl, $method, $body = [])
     {
-
         if (is_null($method)) {
             throw new IsNullException('Method must not be null');
         }
 
-        $response = $this->client->{strtolower($method)}(
+        return $this->client->{strtolower($method)}(
             $this->baseUrl . $relativeUrl,
             ["body" => json_encode($body)]
         );
-
-        return $response;
     }
 
     /**
-     * Formatted SMS Data
-     * Takes varaible and return an array of data to be used in Send SMS Batch, Send SMS Group and Send SM File requests
+     * Build the payload array for Send SMS Batch, Group, or File requests.
      *
-     * @param [type] $sendMethod
-     * @param [type] $message
-     * @param [type] $messageType
-     * @param [type] $contacts
-     * @param [type] $groupIds
-     * @return void
+     * @param  string|null  $contacts
+     * @param  string|null  $groupIds
+     * @param  mixed  $file
+     * @param  string|null  $scheduled
+     * @return array<string, mixed>
      */
-    private function formattedSmsData($sendMethod, $message, $messageType, $contacts = null,  $groupIds = null, $file = null, $scheduled = null)
+    private function formattedSmsData(string $sendMethod, ?string $message, string $messageType, $contacts = null, $groupIds = null, $file = null, $scheduled = null): array
     {
         $data = array_filter([
             "userid" => $this->username,
@@ -182,12 +168,11 @@ class Hostpinnacle
     }
 
     /**
-     * Send Quick SMS
-     * Send SMS in batches. You can send single SMS or comma separated mobile numbers.
-     * Country code is must for international messaging.
+     * Send quick SMS in batches (single or comma-separated mobiles). Country code required for international.
      *
-     * @param [type] $data
-     * @return void
+     * @param  array{msg: string, mobile: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
      */
     public function sendQuickSMS($data)
     {
@@ -197,23 +182,21 @@ class Hostpinnacle
 
         $payload = $this->formattedSmsData('quick', $data['msg'], 'text', $data['mobile']);
 
-        $response = Http::asForm()->withHeaders([
+        return Http::asForm()->withHeaders([
             'apikey' => $this->apiKey,
             'cache-control' => 'no-cache'
         ])->post(
             $this->baseUrl . '/send',
             $payload
         );
-
-
-        return $response;
     }
 
     /**
-     * Send Quick Scheduled SMS.
+     * Send quick SMS at a scheduled date/time.
      *
-     * @param [type] $data
-     * @return void
+     * @param  array{msg: string, mobile: string, scheduledTime: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
      */
     public function sendQuickScheduledSMS($data)
     {
@@ -223,25 +206,21 @@ class Hostpinnacle
 
         $payload = $this->formattedSmsData('quick', $data['msg'], 'text', $data['mobile'], null, null, $data['scheduledTime']);
 
-        $response = Http::asForm()->withHeaders([
+        return Http::asForm()->withHeaders([
             'apikey' => $this->apiKey,
             'cache-control' => 'no-cache'
         ])->post(
             $this->baseUrl . '/send',
             $payload
         );
-
-
-        return $response;
     }
 
     /**
-     * Send SMS Group
-     * Send SMS to your groups. You can send to single group or comma separated groups.
-     * Country code is must for international messaging.
+     * Send SMS to one or more groups (single or comma-separated group IDs). Country code required for international.
      *
-     * @param [type] $data
-     * @return void
+     * @param  array{msg: string, groupIds: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
      */
     public function sendGroupSMS($data)
     {
@@ -251,24 +230,21 @@ class Hostpinnacle
 
         $payload = $this->formattedSmsData('group', $data['msg'], 'text', null, $data['groupIds']);
 
-        $response = Http::asForm()->withHeaders([
+        return Http::asForm()->withHeaders([
             'apikey' => $this->apiKey,
             'cache-control' => 'no-cache'
         ])->get(
             $this->baseUrl . '/send',
             $payload
         );
-
-        return $response;
     }
 
     /**
-     * Send SMS Group Scheduled
-     * Send SMS to your groups. You can send to single group or comma separated groups.
-     * Country code is must for international messaging.
+     * Send group SMS at a scheduled date/time.
      *
-     * @param [type] $data
-     * @return void
+     * @param  array{msg: string, groupIds: string, scheduledTime: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
      */
     public function sendGroupScheduledSMS($data)
     {
@@ -278,21 +254,21 @@ class Hostpinnacle
 
         $payload = $this->formattedSmsData('group', $data['msg'], 'text', null, $data['groupIds'], null, $data['scheduledTime']);
 
-        $response = Http::asForm()->withHeaders([
+        return Http::asForm()->withHeaders([
             'apikey' => $this->apiKey,
             'cache-control' => 'no-cache'
         ])->get(
             $this->baseUrl . '/send',
             $payload
         );
-
-        return $response;
     }
 
     /**
-     * Send Mobile Only File SMS
-     * Send SMS using File Upload. You can upload only mobile in a file with the first row being the header (Phone)
-     * Country code is must for international messaging eg 254720000000
+     * Send SMS from file with mobile numbers only (first row header: Phone). Country code required e.g. 254720000000.
+     *
+     * @param  array{msg: string, file: \Illuminate\Http\UploadedFile|object}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
      */
     public function sendMobileOnlyFileSMS($data)
     {
@@ -304,7 +280,7 @@ class Hostpinnacle
 
         $extension = $data['file']->getClientOriginalExtension();
 
-        $response = Http::withHeaders([
+        return Http::withHeaders([
             'apikey' => $this->apiKey,
         ])->attach(
             'file',
@@ -314,14 +290,14 @@ class Hostpinnacle
             $this->baseUrl . '/send',
             $payload
         );
-
-        return $response;
     }
 
     /**
-     * Send Mobile Only File Scheduled SMS
-     * Send SMS later on a scheduled data/time using File Upload. You can upload only mobile in a file with the first row being the header (Phone)
-     * Country code is must for international messaging eg 254720000000
+     * Send SMS from file (mobile numbers only) at a scheduled date/time.
+     *
+     * @param  array{msg: string, file: \Illuminate\Http\UploadedFile|object, scheduledTime: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
      */
     public function sendMobileOnlyFileScheduledSMS($data)
     {
@@ -333,7 +309,7 @@ class Hostpinnacle
 
         $extension = $data['file']->getClientOriginalExtension();
 
-        $response = Http::withHeaders([
+        return Http::withHeaders([
             'apikey' => $this->apiKey,
         ])->attach(
             'file',
@@ -343,14 +319,14 @@ class Hostpinnacle
             $this->baseUrl . '/send',
             $payload
         );
-
-        return $response;
     }
 
     /**
-     * Send Mobile and Message File SMS
-     * Send SMS using File Upload. You can upload only mobile in a file with the first row being the header (Phone, Message)
-     * Country code is must for international messaging eg 254720000000
+     * Send SMS from file with mobile numbers and message (first row header: Phone, Message). Country code required.
+     *
+     * @param  array{file: \Illuminate\Http\UploadedFile|object}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
      */
     public function sendMobileAndMessageFileSMS($data)
     {
@@ -362,7 +338,7 @@ class Hostpinnacle
 
         $extension = $data['file']->getClientOriginalExtension();
 
-        $response = Http::withHeaders([
+        return Http::withHeaders([
             'apikey' => $this->apiKey,
         ])->attach(
             'file',
@@ -372,14 +348,14 @@ class Hostpinnacle
             $this->baseUrl . '/send',
             $payload
         );
-
-        return $response;
     }
 
     /**
-     * Send Mobile and Message File Scheduled SMS
-     * Send SMS later on a scheduled data/time using File Upload. You can upload only mobile in a file with the first row being the header (Phone, Message)
-     * Country code is must for international messaging eg 254720000000
+     * Send SMS from file (mobile + message) at a scheduled date/time.
+     *
+     * @param  array{file: \Illuminate\Http\UploadedFile|object, scheduledTime: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
      */
     public function sendMobileAndMessageFileScheduledSMS($data)
     {
@@ -391,7 +367,7 @@ class Hostpinnacle
 
         $extension = $data['file']->getClientOriginalExtension();
 
-        $response = Http::withHeaders([
+        return Http::withHeaders([
             'apikey' => $this->apiKey,
         ])->attach(
             'file',
@@ -401,7 +377,5 @@ class Hostpinnacle
             $this->baseUrl . '/send',
             $payload
         );
-
-        return $response;
     }
 }

--- a/src/Hostpinnacle.php
+++ b/src/Hostpinnacle.php
@@ -48,15 +48,17 @@ class Hostpinnacle
      */
     protected $password;
 
-    public function __construct()
+    public function __construct(?HostpinnacleCredentials $credentials = null)
     {
+        $creds = $credentials ?? HostpinnacleCredentials::fromConfig();
 
-        $this->setApiKey();
-        $this->setBaseUrl();
+        $this->apiKey = $creds->getApiKey();
+        $this->senderId = $creds->getSenderId();
+        $this->username = $creds->getUsername();
+        $this->password = $creds->getPassword();
+        $this->baseUrl = $creds->getBaseUrl() ?? Config::get('hostpinnacle.baseUrl');
+
         $this->setRequestOptions();
-        $this->setSenderId();
-        $this->setUsername();
-        $this->setPassword();
     }
 
     /**

--- a/src/HostpinnacleCredentials.php
+++ b/src/HostpinnacleCredentials.php
@@ -4,6 +4,9 @@ namespace Itsmurumba\Hostpinnacle;
 
 use Illuminate\Support\Facades\Config;
 
+/**
+ * Value object for Hostpinnacle API credentials.
+ */
 class HostpinnacleCredentials
 {
     public function __construct(
@@ -14,6 +17,11 @@ class HostpinnacleCredentials
         protected ?string $baseUrl = null
     ) {}
 
+    /**
+     * Create credentials from the hostpinnacle config (env).
+     *
+     * @return static
+     */
     public static function fromConfig(): self
     {
         $config = Config::get('hostpinnacle', []);
@@ -27,6 +35,12 @@ class HostpinnacleCredentials
         );
     }
 
+    /**
+     * Create credentials from an array (supports snake_case or camelCase keys).
+     *
+     * @param  array{api_key?: string, apiKey?: string, sender_id?: string, senderId?: string, username?: string, password?: string, base_url?: string, baseUrl?: string}  $array
+     * @return static
+     */
     public static function fromArray(array $array): self
     {
         return new self(
@@ -40,26 +54,31 @@ class HostpinnacleCredentials
         );
     }
 
+    /** Get the API key. */
     public function getApiKey(): string
     {
         return $this->apiKey;
     }
 
+    /** Get the sender ID. */
     public function getSenderId(): string
     {
         return $this->senderId;
     }
 
+    /** Get the username. */
     public function getUsername(): string
     {
         return $this->username;
     }
 
+    /** Get the password. */
     public function getPassword(): string
     {
         return $this->password;
     }
 
+    /** Get the base URL (null if not set). */
     public function getBaseUrl(): ?string
     {
         return $this->baseUrl;

--- a/src/HostpinnacleCredentials.php
+++ b/src/HostpinnacleCredentials.php
@@ -43,14 +43,15 @@ class HostpinnacleCredentials
      */
     public static function fromArray(array $array): self
     {
+        $baseUrl = $array['base_url'] ?? $array['baseUrl'] ?? null;
+        $baseUrl = ($baseUrl !== null && $baseUrl !== '') ? (string) $baseUrl : null;
+
         return new self(
             (string) ($array['api_key'] ?? $array['apiKey'] ?? ''),
             (string) ($array['sender_id'] ?? $array['senderId'] ?? ''),
             (string) ($array['username'] ?? ''),
             (string) ($array['password'] ?? ''),
-            isset($array['base_url']) || isset($array['baseUrl'])
-                ? (string) ($array['base_url'] ?? $array['baseUrl'] ?? '')
-                : null
+            $baseUrl
         );
     }
 

--- a/src/HostpinnacleCredentials.php
+++ b/src/HostpinnacleCredentials.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle;
+
+use Illuminate\Support\Facades\Config;
+
+class HostpinnacleCredentials
+{
+    public function __construct(
+        protected string $apiKey,
+        protected string $senderId,
+        protected string $username,
+        protected string $password,
+        protected ?string $baseUrl = null
+    ) {}
+
+    public static function fromConfig(): self
+    {
+        $config = Config::get('hostpinnacle', []);
+
+        return new self(
+            (string) ($config['apiKey'] ?? ''),
+            (string) ($config['senderId'] ?? ''),
+            (string) ($config['username'] ?? ''),
+            (string) ($config['password'] ?? ''),
+            isset($config['baseUrl']) && $config['baseUrl'] !== '' ? (string) $config['baseUrl'] : null
+        );
+    }
+
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            (string) ($array['api_key'] ?? $array['apiKey'] ?? ''),
+            (string) ($array['sender_id'] ?? $array['senderId'] ?? ''),
+            (string) ($array['username'] ?? ''),
+            (string) ($array['password'] ?? ''),
+            isset($array['base_url']) || isset($array['baseUrl'])
+                ? (string) ($array['base_url'] ?? $array['baseUrl'] ?? '')
+                : null
+        );
+    }
+
+    public function getApiKey(): string
+    {
+        return $this->apiKey;
+    }
+
+    public function getSenderId(): string
+    {
+        return $this->senderId;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function getBaseUrl(): ?string
+    {
+        return $this->baseUrl;
+    }
+}

--- a/src/HostpinnacleFactory.php
+++ b/src/HostpinnacleFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle;
+
+use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
+
+class HostpinnacleFactory
+{
+    /**
+     * Create a Hostpinnacle instance for the given account or credentials.
+     *
+     * @param  HostpinnacleAccount|HostpinnacleCredentials  $accountOrCredentials
+     * @return Hostpinnacle
+     */
+    public function for(HostpinnacleAccount|HostpinnacleCredentials $accountOrCredentials): Hostpinnacle
+    {
+        $credentials = $accountOrCredentials instanceof HostpinnacleAccount
+            ? $accountOrCredentials->toCredentials()
+            : $accountOrCredentials;
+
+        return new Hostpinnacle($credentials);
+    }
+}

--- a/src/HostpinnacleFactory.php
+++ b/src/HostpinnacleFactory.php
@@ -4,6 +4,9 @@ namespace Itsmurumba\Hostpinnacle;
 
 use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
 
+/**
+ * Creates Hostpinnacle instances for a given account or credentials (SaaS).
+ */
 class HostpinnacleFactory
 {
     /**

--- a/src/HostpinnacleServiceProvider.php
+++ b/src/HostpinnacleServiceProvider.php
@@ -7,10 +7,15 @@ use Itsmurumba\Hostpinnacle\Hostpinnacle;
 use Itsmurumba\Hostpinnacle\Console\InstallHostpinnaclePackage;
 use Itsmurumba\Hostpinnacle\HostpinnacleFactory;
 
+/**
+ * Service provider for the Hostpinnacle package. Registers config, migrations, routes, and bindings.
+ */
 class HostpinnacleServiceProvider extends ServiceProvider
 {
     /**
-     * Publishes all the config file this package needs to function
+     * Bootstrap the package: publish config/migrations, load SaaS routes when enabled.
+     *
+     * @return void
      */
     public function boot()
     {
@@ -43,7 +48,9 @@ class HostpinnacleServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the application services
+     * Register the package services: hostpinnacle singleton and HostpinnacleFactory.
+     *
+     * @return void
      */
     public function register()
     {
@@ -59,8 +66,9 @@ class HostpinnacleServiceProvider extends ServiceProvider
     }
 
     /**
-     * Get the services provided by the provider
-     * @return array
+     * Get the services provided by the provider.
+     *
+     * @return array<int, string>
      */
     public function provides()
     {

--- a/src/HostpinnacleServiceProvider.php
+++ b/src/HostpinnacleServiceProvider.php
@@ -5,6 +5,7 @@ namespace Itsmurumba\Hostpinnacle;
 use Illuminate\Support\ServiceProvider;
 use Itsmurumba\Hostpinnacle\Hostpinnacle;
 use Itsmurumba\Hostpinnacle\Console\InstallHostpinnaclePackage;
+use Itsmurumba\Hostpinnacle\HostpinnacleFactory;
 
 class HostpinnacleServiceProvider extends ServiceProvider
 {
@@ -15,10 +16,25 @@ class HostpinnacleServiceProvider extends ServiceProvider
     {
         $config = realpath(__DIR__ . '/../config/hostpinnacle.php');
 
+        if (config('hostpinnacle.saas.enabled', false)) {
+            $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+
+            if (config('hostpinnacle.saas.api_routes_enabled', true)) {
+                $this->loadRoutesFrom(__DIR__ . '/../routes/api.php');
+            }
+            if (config('hostpinnacle.saas.web_routes_enabled', true)) {
+                $this->loadRoutesFrom(__DIR__ . '/../routes/web.php');
+            }
+        }
+
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 $config => config_path('hostpinnacle.php')
             ], 'hostpinnacle-config');
+
+            $this->publishes([
+                __DIR__ . '/../database/migrations' => database_path('migrations'),
+            ], 'hostpinnacle-migrations');
 
             $this->commands([
                 InstallHostpinnaclePackage::class,
@@ -31,9 +47,14 @@ class HostpinnacleServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind('laravel-hostpinnacle', function () {
+        $this->app->singleton('hostpinnacle', function () {
+            return new Hostpinnacle();
+        });
 
-            return new Hostpinnacle;
+        $this->app->alias('hostpinnacle', 'laravel-hostpinnacle');
+
+        $this->app->singleton(HostpinnacleFactory::class, function () {
+            return new HostpinnacleFactory();
         });
     }
 
@@ -43,7 +64,6 @@ class HostpinnacleServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-
-        return ['laravel-hostpinnacle'];
+        return ['hostpinnacle', 'laravel-hostpinnacle'];
     }
 }

--- a/src/HostpinnacleServiceProvider.php
+++ b/src/HostpinnacleServiceProvider.php
@@ -48,12 +48,14 @@ class HostpinnacleServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the package services: hostpinnacle singleton and HostpinnacleFactory.
+     * Register the package services: merge default config, hostpinnacle singleton and HostpinnacleFactory.
      *
      * @return void
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__ . '/../config/hostpinnacle.php', 'hostpinnacle');
+
         $this->app->singleton('hostpinnacle', function () {
             return new Hostpinnacle();
         });

--- a/src/Http/Controllers/HostpinnacleAccountController.php
+++ b/src/Http/Controllers/HostpinnacleAccountController.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+use Itsmurumba\Hostpinnacle\Http\Resources\HostpinnacleAccountResource;
+use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
+
+class HostpinnacleAccountController extends Controller
+{
+    protected function ownerId(): ?int
+    {
+        $user = Auth::user();
+        if ($user === null) {
+            return null;
+        }
+        return (int) $user->getAuthIdentifier();
+    }
+
+    protected function query(): \Illuminate\Database\Eloquent\Builder
+    {
+        $key = config('hostpinnacle.saas.owner_key', 'user_id');
+        $ownerId = $this->ownerId();
+
+        return HostpinnacleAccount::query()->where($key, $ownerId);
+    }
+
+    public function index(): JsonResponse|RedirectResponse
+    {
+        $accounts = $this->query()->get();
+
+        if (request()->wantsJson()) {
+            return response()->json([
+                'data' => HostpinnacleAccountResource::collection($accounts),
+            ]);
+        }
+
+        return redirect()->back()->with('hostpinnacle_accounts', $accounts);
+    }
+
+    public function show(HostpinnacleAccount $account): JsonResponse|RedirectResponse
+    {
+        $this->authorizeAccount($account);
+
+        if (request()->wantsJson()) {
+            return response()->json([
+                'data' => new HostpinnacleAccountResource($account),
+            ]);
+        }
+
+        return redirect()->back()->with('hostpinnacle_account', $account);
+    }
+
+    public function store(Request $request): JsonResponse|RedirectResponse
+    {
+        $validated = $request->validate([
+            'api_key' => ['required', 'string', 'max:255'],
+            'sender_id' => ['required', 'string', 'max:50'],
+            'username' => ['required', 'string', 'max:255'],
+            'password' => ['required', 'string', 'max:255'],
+            'base_url' => ['nullable', 'string', 'url', 'max:255'],
+            'name' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $key = config('hostpinnacle.saas.owner_key', 'user_id');
+        $validated[$key] = $this->ownerId();
+
+        $account = HostpinnacleAccount::create($validated);
+
+        if (request()->wantsJson()) {
+            return response()->json([
+                'data' => new HostpinnacleAccountResource($account),
+                'message' => __('Hostpinnacle account created.'),
+            ], 201);
+        }
+
+        return redirect()->back()->with('success', __('Hostpinnacle account created.'));
+    }
+
+    public function update(Request $request, HostpinnacleAccount $account): JsonResponse|RedirectResponse
+    {
+        $this->authorizeAccount($account);
+
+        $validated = $request->validate([
+            'api_key' => ['sometimes', 'string', 'max:255'],
+            'sender_id' => ['sometimes', 'string', 'max:50'],
+            'username' => ['sometimes', 'string', 'max:255'],
+            'password' => ['nullable', 'string', 'max:255'],
+            'base_url' => ['nullable', 'string', 'url', 'max:255'],
+            'name' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        if (($validated['password'] ?? '') === '') {
+            unset($validated['password']);
+        }
+
+        $account->update($validated);
+
+        if (request()->wantsJson()) {
+            return response()->json([
+                'data' => new HostpinnacleAccountResource($account->fresh()),
+                'message' => __('Hostpinnacle account updated.'),
+            ]);
+        }
+
+        return redirect()->back()->with('success', __('Hostpinnacle account updated.'));
+    }
+
+    public function destroy(HostpinnacleAccount $account): JsonResponse|RedirectResponse
+    {
+        $this->authorizeAccount($account);
+        $account->delete();
+
+        if (request()->wantsJson()) {
+            return response()->json([
+                'message' => __('Hostpinnacle account deleted.'),
+            ]);
+        }
+
+        return redirect()->back()->with('success', __('Hostpinnacle account deleted.'));
+    }
+
+    protected function authorizeAccount(HostpinnacleAccount $account): void
+    {
+        $key = config('hostpinnacle.saas.owner_key', 'user_id');
+        $ownerId = $this->ownerId();
+        if ((int) $account->getAttribute($key) !== $ownerId) {
+            abort(403, __('You do not own this Hostpinnacle account.'));
+        }
+    }
+}

--- a/src/Http/Controllers/HostpinnacleAccountController.php
+++ b/src/Http/Controllers/HostpinnacleAccountController.php
@@ -24,7 +24,7 @@ class HostpinnacleAccountController extends Controller
     {
         $user = Auth::user();
         if ($user === null) {
-            return null;
+            abort(401, __('Authentication required.'));
         }
         return (int) $user->getAuthIdentifier();
     }

--- a/src/Http/Controllers/HostpinnacleAccountController.php
+++ b/src/Http/Controllers/HostpinnacleAccountController.php
@@ -10,8 +10,16 @@ use Illuminate\Support\Facades\Auth;
 use Itsmurumba\Hostpinnacle\Http\Resources\HostpinnacleAccountResource;
 use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
 
+/**
+ * CRUD controller for Hostpinnacle accounts (SaaS). Responds with JSON for API/wantsJson, redirect+flash for web.
+ */
 class HostpinnacleAccountController extends Controller
 {
+    /**
+     * Get the current authenticated owner ID (from config owner key).
+     *
+     * @return int|null
+     */
     protected function ownerId(): ?int
     {
         $user = Auth::user();
@@ -21,6 +29,11 @@ class HostpinnacleAccountController extends Controller
         return (int) $user->getAuthIdentifier();
     }
 
+    /**
+     * Query scope: accounts belonging to the current owner.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<HostpinnacleAccount>
+     */
     protected function query(): \Illuminate\Database\Eloquent\Builder
     {
         $key = config('hostpinnacle.saas.owner_key', 'user_id');
@@ -29,6 +42,11 @@ class HostpinnacleAccountController extends Controller
         return HostpinnacleAccount::query()->where($key, $ownerId);
     }
 
+    /**
+     * List the current owner's Hostpinnacle accounts.
+     *
+     * @return JsonResponse|RedirectResponse
+     */
     public function index(): JsonResponse|RedirectResponse
     {
         $accounts = $this->query()->get();
@@ -42,6 +60,12 @@ class HostpinnacleAccountController extends Controller
         return redirect()->back()->with('hostpinnacle_accounts', $accounts);
     }
 
+    /**
+     * Show a single Hostpinnacle account (owner-only).
+     *
+     * @param  HostpinnacleAccount  $account
+     * @return JsonResponse|RedirectResponse
+     */
     public function show(HostpinnacleAccount $account): JsonResponse|RedirectResponse
     {
         $this->authorizeAccount($account);
@@ -55,6 +79,11 @@ class HostpinnacleAccountController extends Controller
         return redirect()->back()->with('hostpinnacle_account', $account);
     }
 
+    /**
+     * Create a new Hostpinnacle account for the current owner.
+     *
+     * @return JsonResponse|RedirectResponse
+     */
     public function store(Request $request): JsonResponse|RedirectResponse
     {
         $validated = $request->validate([
@@ -81,6 +110,12 @@ class HostpinnacleAccountController extends Controller
         return redirect()->back()->with('success', __('Hostpinnacle account created.'));
     }
 
+    /**
+     * Update a Hostpinnacle account (owner-only).
+     *
+     * @param  HostpinnacleAccount  $account
+     * @return JsonResponse|RedirectResponse
+     */
     public function update(Request $request, HostpinnacleAccount $account): JsonResponse|RedirectResponse
     {
         $this->authorizeAccount($account);
@@ -110,6 +145,12 @@ class HostpinnacleAccountController extends Controller
         return redirect()->back()->with('success', __('Hostpinnacle account updated.'));
     }
 
+    /**
+     * Delete a Hostpinnacle account (owner-only).
+     *
+     * @param  HostpinnacleAccount  $account
+     * @return JsonResponse|RedirectResponse
+     */
     public function destroy(HostpinnacleAccount $account): JsonResponse|RedirectResponse
     {
         $this->authorizeAccount($account);
@@ -124,6 +165,12 @@ class HostpinnacleAccountController extends Controller
         return redirect()->back()->with('success', __('Hostpinnacle account deleted.'));
     }
 
+    /**
+     * Ensure the current user owns the account; abort 403 otherwise.
+     *
+     * @param  HostpinnacleAccount  $account
+     * @return void
+     */
     protected function authorizeAccount(HostpinnacleAccount $account): void
     {
         $key = config('hostpinnacle.saas.owner_key', 'user_id');

--- a/src/Http/Controllers/HostpinnacleAccountController.php
+++ b/src/Http/Controllers/HostpinnacleAccountController.php
@@ -17,20 +17,23 @@ class HostpinnacleAccountController extends Controller
 {
     /**
      * Get the current authenticated owner ID (from config owner key).
+     * Supports integer or string identifiers (e.g. UUID).
      *
-     * @return int|null
+     * @return int|string|null
      */
-    protected function ownerId(): ?int
+    protected function ownerId(): int|string|null
     {
         $user = Auth::user();
         if ($user === null) {
             return null;
         }
-        return (int) $user->getAuthIdentifier();
+        return $user->getAuthIdentifier();
     }
 
     /**
      * Query scope: accounts belonging to the current owner.
+     *
+     * owner_key must match the column created by the migration (do not change saas.owner_key after migrating).
      *
      * @return \Illuminate\Database\Eloquent\Builder<HostpinnacleAccount>
      */
@@ -167,6 +170,7 @@ class HostpinnacleAccountController extends Controller
 
     /**
      * Ensure the current user owns the account; abort 403 otherwise.
+     * Comparison uses string cast so both integer and string (e.g. UUID) owner keys work.
      *
      * @param  HostpinnacleAccount  $account
      * @return void
@@ -175,7 +179,7 @@ class HostpinnacleAccountController extends Controller
     {
         $key = config('hostpinnacle.saas.owner_key', 'user_id');
         $ownerId = $this->ownerId();
-        if ((int) $account->getAttribute($key) !== $ownerId) {
+        if ($ownerId === null || (string) $account->getAttribute($key) !== (string) $ownerId) {
             abort(403, __('You do not own this Hostpinnacle account.'));
         }
     }

--- a/src/Http/Resources/HostpinnacleAccountResource.php
+++ b/src/Http/Resources/HostpinnacleAccountResource.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
+
+/** @mixin HostpinnacleAccount */
+class HostpinnacleAccountResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'sender_id' => $this->sender_id,
+            'username' => $this->username,
+            'api_key' => $this->maskApiKey($this->api_key),
+            'base_url' => $this->base_url,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+
+    private function maskApiKey(?string $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $len = strlen($value);
+        if ($len <= 8) {
+            return str_repeat('*', $len);
+        }
+        return substr($value, 0, 4) . str_repeat('*', $len - 8) . substr($value, -4);
+    }
+}

--- a/src/Http/Resources/HostpinnacleAccountResource.php
+++ b/src/Http/Resources/HostpinnacleAccountResource.php
@@ -6,9 +6,19 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
 
-/** @mixin HostpinnacleAccount */
+/**
+ * API resource for HostpinnacleAccount. Masks api_key; never exposes password.
+ *
+ * @mixin HostpinnacleAccount
+ */
 class HostpinnacleAccountResource extends JsonResource
 {
+    /**
+     * Transform the resource into an array for JSON responses.
+     *
+     * @param  Request  $request
+     * @return array<string, mixed>
+     */
     public function toArray(Request $request): array
     {
         return [
@@ -23,6 +33,12 @@ class HostpinnacleAccountResource extends JsonResource
         ];
     }
 
+    /**
+     * Mask the API key for safe display (show first 4 and last 4 characters).
+     *
+     * @param  string|null  $value
+     * @return string|null
+     */
     private function maskApiKey(?string $value): ?string
     {
         if ($value === null || $value === '') {

--- a/src/Models/HostpinnacleAccount.php
+++ b/src/Models/HostpinnacleAccount.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Itsmurumba\Hostpinnacle\HostpinnacleCredentials;
+
+class HostpinnacleAccount extends Model
+{
+    protected $table;
+
+    protected $fillable = [
+        'api_key',
+        'sender_id',
+        'username',
+        'password',
+        'base_url',
+        'name',
+    ];
+
+    protected $casts = [
+        'password' => 'encrypted',
+    ];
+
+    protected $hidden = [
+        'password',
+    ];
+
+    public function __construct(array $attributes = [])
+    {
+        $this->table = config('hostpinnacle.saas.table', 'hostpinnacle_accounts');
+        parent::__construct($attributes);
+    }
+
+    /**
+     * Owner of this account (e.g. User). Configure owner_model and owner_key in config.
+     */
+    public function owner(): BelongsTo
+    {
+        $key = config('hostpinnacle.saas.owner_key', 'user_id');
+        $model = config('hostpinnacle.saas.owner_model', 'App\\Models\\User');
+
+        return $this->belongsTo($model, $key);
+    }
+
+    /**
+     * Convert this account to credentials for use with Hostpinnacle.
+     */
+    public function toCredentials(): HostpinnacleCredentials
+    {
+        return HostpinnacleCredentials::fromArray([
+            'api_key' => $this->api_key,
+            'sender_id' => $this->sender_id,
+            'username' => $this->username,
+            'password' => $this->password,
+            'base_url' => $this->base_url,
+        ]);
+    }
+}

--- a/src/Models/HostpinnacleAccount.php
+++ b/src/Models/HostpinnacleAccount.php
@@ -35,13 +35,17 @@ class HostpinnacleAccount extends Model
     ];
 
     /**
-     * Table name is read from config (hostpinnacle.saas.table).
+     * Table name and owner key are read from config so mass assignment includes the owner column.
      *
      * @param  array<string, mixed>  $attributes
      */
     public function __construct(array $attributes = [])
     {
         $this->table = config('hostpinnacle.saas.table', 'hostpinnacle_accounts');
+        $ownerKey = config('hostpinnacle.saas.owner_key', 'user_id');
+        if (! in_array($ownerKey, $this->fillable, true)) {
+            $this->fillable = array_merge($this->fillable, [$ownerKey]);
+        }
         parent::__construct($attributes);
     }
 

--- a/src/Models/HostpinnacleAccount.php
+++ b/src/Models/HostpinnacleAccount.php
@@ -6,10 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Itsmurumba\Hostpinnacle\HostpinnacleCredentials;
 
+/**
+ * Stored Hostpinnacle account (credentials) for SaaS multi-account usage.
+ */
 class HostpinnacleAccount extends Model
 {
+    /** @var string|null */
     protected $table;
 
+    /** @var array<int, string> */
     protected $fillable = [
         'api_key',
         'sender_id',
@@ -19,14 +24,21 @@ class HostpinnacleAccount extends Model
         'name',
     ];
 
+    /** @var array<string, string> */
     protected $casts = [
         'password' => 'encrypted',
     ];
 
+    /** @var array<int, string> */
     protected $hidden = [
         'password',
     ];
 
+    /**
+     * Table name is read from config (hostpinnacle.saas.table).
+     *
+     * @param  array<string, mixed>  $attributes
+     */
     public function __construct(array $attributes = [])
     {
         $this->table = config('hostpinnacle.saas.table', 'hostpinnacle_accounts');
@@ -35,6 +47,8 @@ class HostpinnacleAccount extends Model
 
     /**
      * Owner of this account (e.g. User). Configure owner_model and owner_key in config.
+     *
+     * @return BelongsTo
      */
     public function owner(): BelongsTo
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,6 +28,7 @@ class TestCase extends TestbenchTestCase
 
     protected function getEnvironmentSetUp($app)
     {
+        $app['config']->set('app.key', 'base64:' . base64_encode(\Illuminate\Support\Str::random(32)));
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Hostpinnacle/HostpinnacleAccountTest.php
+++ b/tests/Unit/Hostpinnacle/HostpinnacleAccountTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\HostpinnacleCredentials;
+use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
+
+beforeEach(function () {
+    config()->set('hostpinnacle.saas.table', 'hostpinnacle_accounts');
+    config()->set('hostpinnacle.saas.owner_key', 'user_id');
+});
+
+test('HostpinnacleAccount toCredentials returns HostpinnacleCredentials with model attributes', function () {
+    $account = new HostpinnacleAccount([
+        'api_key' => 'test-api-key',
+        'sender_id' => 'SENDER',
+        'username' => 'user',
+        'password' => 'secret',
+        'base_url' => 'https://api.test',
+        'name' => 'Test Account',
+    ]);
+
+    $credentials = $account->toCredentials();
+
+    expect($credentials)->toBeInstanceOf(HostpinnacleCredentials::class)
+        ->and($credentials->getApiKey())->toBe('test-api-key')
+        ->and($credentials->getSenderId())->toBe('SENDER')
+        ->and($credentials->getUsername())->toBe('user')
+        ->and($credentials->getPassword())->toBe('secret')
+        ->and($credentials->getBaseUrl())->toBe('https://api.test');
+});
+
+test('HostpinnacleAccount toCredentials works with null base_url', function () {
+    $account = new HostpinnacleAccount([
+        'api_key' => 'key',
+        'sender_id' => 'ID',
+        'username' => 'u',
+        'password' => 'p',
+        'base_url' => null,
+    ]);
+
+    $credentials = $account->toCredentials();
+
+    expect($credentials->getBaseUrl())->toBeNull();
+});
+
+test('HostpinnacleAccount owner relationship uses config owner_key and owner_model', function () {
+    config()->set('hostpinnacle.saas.owner_model', 'Workbench\\App\\Models\\User');
+
+    $account = new HostpinnacleAccount();
+    $relation = $account->owner();
+
+    expect($relation)->toBeInstanceOf(\Illuminate\Database\Eloquent\Relations\BelongsTo::class);
+    $ownerKey = config('hostpinnacle.saas.owner_key', 'user_id');
+    expect($relation->getForeignKeyName())->toBe($ownerKey);
+});

--- a/tests/Unit/Hostpinnacle/HostpinnacleCredentialsTest.php
+++ b/tests/Unit/Hostpinnacle/HostpinnacleCredentialsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Http\Client\Response;
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\HostpinnacleCredentials;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('Hostpinnacle uses credentials from HostpinnacleCredentials when provided', function () {
+    Http::fake([
+        'https://custom.api.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $credentials = new HostpinnacleCredentials(
+        'custom-api-key',
+        'CUSTOMID',
+        'customuser',
+        'custompass',
+        'https://custom.api.test'
+    );
+
+    $hostpinnacle = new Hostpinnacle($credentials);
+    /** @var Response $response */
+    $response = $hostpinnacle->sendQuickSMS([
+        'msg' => 'Test',
+        'mobile' => '254700000000',
+    ]);
+
+    expect($response)->not->toBeNull();
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), 'https://custom.api.test/send')
+            && $request->hasHeader('apikey', 'custom-api-key');
+    });
+});
+
+test('Hostpinnacle uses config when constructed with null credentials', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $hostpinnacle = new Hostpinnacle();
+    /** @var Response $response */
+    $response = $hostpinnacle->sendQuickSMS([
+        'msg' => 'Test',
+        'mobile' => '254700000000',
+    ]);
+
+    expect($response)->not->toBeNull();
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->hasHeader('apikey', 'test-api-key');
+    });
+});

--- a/tests/Unit/Hostpinnacle/HostpinnacleFactoryTest.php
+++ b/tests/Unit/Hostpinnacle/HostpinnacleFactoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Http\Client\Response;
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\HostpinnacleCredentials;
+use Itsmurumba\Hostpinnacle\HostpinnacleFactory;
+use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+    config()->set('hostpinnacle.saas.table', 'hostpinnacle_accounts');
+});
+
+test('HostpinnacleFactory for HostpinnacleCredentials returns Hostpinnacle using those credentials', function () {
+    Http::fake([
+        'https://factory-api.test/send*' => Http::response(['status' => 'ok'], 200),
+    ]);
+
+    $credentials = new HostpinnacleCredentials(
+        'factory-key',
+        'FID',
+        'factoryuser',
+        'factorypass',
+        'https://factory-api.test'
+    );
+
+    $factory = app(HostpinnacleFactory::class);
+    $hostpinnacle = $factory->for($credentials);
+
+    expect($hostpinnacle)->toBeInstanceOf(Hostpinnacle::class);
+
+    /** @var Response $response */
+    $response = $hostpinnacle->sendQuickSMS(['msg' => 'Hi', 'mobile' => '254700000000']);
+    expect($response)->not->toBeNull();
+    expect($response->successful())->toBeTrue();
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), 'https://factory-api.test')
+            && $request->hasHeader('apikey', 'factory-key');
+    });
+});
+
+test('HostpinnacleFactory for HostpinnacleAccount returns Hostpinnacle using account credentials', function () {
+    Http::fake([
+        'https://account-api.test/send*' => Http::response(['status' => 'ok'], 200),
+    ]);
+
+    $account = new HostpinnacleAccount([
+        'api_key' => 'account-key',
+        'sender_id' => 'AID',
+        'username' => 'accountuser',
+        'password' => 'accountpass',
+        'base_url' => 'https://account-api.test',
+    ]);
+
+    $factory = app(HostpinnacleFactory::class);
+    $hostpinnacle = $factory->for($account);
+
+    expect($hostpinnacle)->toBeInstanceOf(Hostpinnacle::class);
+
+    /** @var Response $response */
+    $response = $hostpinnacle->sendQuickSMS(['msg' => 'Hi', 'mobile' => '254700000000']);
+    expect($response)->not->toBeNull();
+    expect($response->successful())->toBeTrue();
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), 'https://account-api.test')
+            && $request->hasHeader('apikey', 'account-key');
+    });
+});
+
+// Hostpinnacle::for($account) is a thin wrapper around app(HostpinnacleFactory::class)->for($account);
+// and is covered by the factory tests above.


### PR DESCRIPTION
## Summary

This PR adds **SaaS / multi-account** support to the Laravel Hostpinnacle package so each tenant/customer can store their own Hostpinnacle credentials and send SMS from their account. Single-account usage (env-based credentials) is unchanged. It also adds **VitePress** documentation, **PHPDoc** standardization, and **testing-before-publish** guidance.

---

## What's new

### SaaS / Multi-Account (optional)

- **Credentials abstraction** — `HostpinnacleCredentials` value object; `Hostpinnacle` constructor accepts optional `?HostpinnacleCredentials` (falls back to config when null).
- **Storage** — Publishable migration `hostpinnacle_accounts`; `HostpinnacleAccount` model with `toCredentials()`, encrypted password, configurable owner (e.g. `user_id`).
- **Factory** — `HostpinnacleFactory::for(Account|Credentials)` and `Hostpinnacle::for($account)` to send SMS using a stored account.
- **API & Web routes** — CRUD for Hostpinnacle accounts when SaaS is enabled (config-gated). Same controller; JSON for API/`wantsJson()`, redirect+flash for web. No UI shipped; implementers build their own.
- **Config** — New `hostpinnacle.saas` options: `enabled`, `table`, `owner_key`/`owner_model`, `encrypt_password`, `api_routes_enabled`/`web_routes_enabled`, prefixes, middleware.

### Documentation

- **VitePress** — Docs site in `docs/` (guide, reference, contributing). Run `npm run docs:dev` (port 5174) or `npm run docs:build`.
- **README** — Slimmed; quick start + link to full docs. New sections: testing locally before publish, SaaS summary.
- **Testing locally** — Path repository and Git-branch instructions for testing the package in a real Laravel app before publishing to Packagist.
- **PHPDoc** — Inline comments replaced with PHPDoc (class/method descriptions, `@param`, `@return`, `@throws`) across `src/`.

### Other

- **Install command** — Copy fixes: "Mpesa" → "Hostpinnacle", "Overwitting" → "Overwriting"; `handle()` returns `self::SUCCESS`.
- **Tests** — Unit tests for credentials injection, `HostpinnacleAccount::toCredentials()`, `HostpinnacleFactory::for()`. All 30 tests passing.

---

## Backward compatibility

- Existing apps using only env and no new config: **no changes required**; behaviour unchanged.
- `new Hostpinnacle()` (no args) and `Hostpinnacle::sendQuickSMS(...)` (facade, no `for`) still use config (env).
- No new required env vars or tables unless the app opts in to SaaS (`hostpinnacle.saas.enabled`).

---

## How to test

1. **Unit tests:** `composer test` or `vendor/bin/pest`.
2. **Single-account:** In a Laravel app, require the package (path repo or branch), set env vars, use `Hostpinnacle::sendQuickSMS([...])`.
3. **SaaS:** Set `HOSTPINNACLE_SAAS_ENABLED=true`, run migration, create an account via API/Web (or model), then `Hostpinnacle::for($account)->sendQuickSMS([...])`.
4. **Docs:** `npm install && npm run docs:dev` → http://localhost:5174.

---

## Checklist

- [x] Single-account behaviour unchanged; tests pass.
- [x] SaaS opt-in via config; migrations and routes gated.
- [x] PHPDoc and descriptions added; no inline comments left in place.
- [x] README and VitePress docs updated; testing-before-publish documented.
- [x] Install command copy and return value fixed.

---

## Files changed (overview)

| Area | Changes |
|------|---------|
| **SaaS core** | `HostpinnacleCredentials`, `Hostpinnacle` refactor, `HostpinnacleAccount`, `HostpinnacleFactory`, migration, config `saas` |
| **Routes / HTTP** | `HostpinnacleAccountController`, `HostpinnacleAccountResource`, `routes/api.php`, `routes/web.php`; provider loads routes when SaaS enabled |
| **Facade** | `Hostpinnacle::for($account)`; alias fix for linter |
| **Docs** | VitePress in `docs/` (config, guide, reference, contributing); README slimmed; testing-locally guide |
| **PHPDoc** | All `src/` classes and methods documented |
| **Console** | `InstallHostpinnaclePackage` copy and return value |
| **Tests** | `HostpinnacleCredentialsTest`, `HostpinnacleAccountTest`, `HostpinnacleFactoryTest`; `TestCase` app key for encrypted cast |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SaaS multi-account support with per-tenant credentials, database migration, and API + web account management; facade/factory API to operate against a specific account.
* **Documentation**
  * New VitePress docs site and expanded README with Quick Start, SaaS guide, configuration, usage, and local testing instructions.
* **Tests**
  * Unit tests covering credentials, factory, and account model behavior.
* **Chores**
  * Docs tooling added, README branding updated, CLI install flow improved, and .gitignore extended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->