### PR TITLE
Cleanup: remove dead code, fill test gaps, add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and other agents) working in this repo.
+
+## What this is
+
+A Laravel package (`itsmurumba/laravel-hostpinnacle`) that wraps the Hostpinnacle SMS API. Two usage modes:
+
+- **Single-account** (default): credentials come from `config/hostpinnacle.php` / `.env`. One set of Hostpinnacle credentials for the whole app.
+- **SaaS multi-account** (opt-in via `hostpinnacle.saas.enabled`): each tenant/user stores their own credentials in the `hostpinnacle_accounts` table and sends SMS through their own account.
+
+Full usage docs live in `docs/` (VitePress site); package/contribution rules are in `Contribution.md`. This file is about *how to work on the package itself*, not how to consume it — see those for the latter.
+
+## Architecture map
+
+```
+Hostpinnacle              SMS client: sendQuickSMS, sendGroupSMS, file-upload SMS, scheduled variants.
+                           Built from HostpinnacleCredentials; uses Illuminate's Http facade to call the API.
+
+HostpinnacleCredentials    Value object holding apiKey/senderId/username/password/baseUrl.
+                           ::fromConfig() reads config/hostpinnacle.php (single-account).
+                           ::fromArray() reads a snake_case or camelCase array (SaaS: from a HostpinnacleAccount).
+
+HostpinnacleFactory        ->for(HostpinnacleAccount|HostpinnacleCredentials): Hostpinnacle
+                           Turns a stored account (or a raw credentials object) into a ready-to-use client.
+
+Facades\Hostpinnacle       Static facade. Hostpinnacle::sendQuickSMS(...) uses the single-account singleton.
+                           Hostpinnacle::for($account)->sendQuickSMS(...) is the SaaS multi-account entry point.
+
+Models\HostpinnacleAccount SaaS storage: one row per tenant's credentials. ->toCredentials() bridges to
+                           HostpinnacleCredentials. Table name, owner column name/type all come from config
+                           (see below) — set before running the migration, not after.
+
+Http\Controllers\HostpinnacleAccountController
+                           CRUD for HostpinnacleAccount, scoped to the authenticated owner (Auth::user()).
+                           Only registered when hostpinnacle.saas.enabled is true (see HostpinnacleServiceProvider::boot).
+                           Enforces its own 401 (no user) / 403 (wrong owner) — not relying solely on route middleware.
+
+Http\Resources\HostpinnacleAccountResource
+                           JSON shape for an account. Masks api_key (first 4 / last 4 chars), never returns password.
+```
+
+## Conventions
+
+- **PSR-2** coding style (per `Contribution.md`).
+- **Pest**, not raw PHPUnit classes: `test('description', function () { ... });` + `expect()`. See any file under `tests/Unit/Hostpinnacle/` for the pattern.
+- **`Illuminate\Support\Facades\Http`** for all outbound API calls — not Guzzle directly, even though Guzzle is a transitive dependency (via `illuminate/http`). Don't add `guzzlehttp/guzzle` back as a direct dependency; it was removed as dead weight (nothing in `src/` used it directly).
+- **Config-driven feature flags with defaults inline**: every `config('hostpinnacle.saas.x', $default)` call repeats the same default as `config/hostpinnacle.php`. If you add a new SaaS config key, follow this pattern rather than assuming the config array is fully populated — see "Testing gotchas" below for why.
+- `IsNullException` extends `InvalidArgumentException` (not a bare `Exception`) — required-argument-missing is exactly what that stdlib type models.
+
+## Commands
+
+- `composer test` / `vendor/bin/pest` — run the suite.
+- `composer test:coverage` / `vendor/bin/pest --coverage` — needs PCOV or Xdebug (see `docs/guide/testing.md`); reports to `build/coverage/`.
+- `php artisan hostpinnacle:install` — publishes `config/hostpinnacle.php` (asks before overwriting).
+
+## Testing patterns
+
+- **Http::fake() for the SMS client** — `tests/Unit/Hostpinnacle/SendQuickSMSTest.php` is the canonical example: fake the endpoint, call the method, assert on `Http::assertSent(...)`.
+- **SaaS model/credentials tests** — `tests/Unit/Hostpinnacle/HostpinnacleAccountTest.php`: build a `HostpinnacleAccount` in memory (no DB needed) and assert `toCredentials()`/relationship behavior.
+- **SaaS HTTP/route tests** (`tests/Feature/`) run under `Itsmurumba\Hostpinnacle\Tests\Support\SaasEnabledTestCase`, wired in `tests/Pest.php` via `uses(SaasEnabledTestCase::class)->in('Feature')`. That TestCase flips `hostpinnacle.saas.enabled` on in `getEnvironmentSetUp()` — config changes made later in a test's `beforeEach()` are too late to affect route registration, since `HostpinnacleServiceProvider::boot()` (which conditionally registers routes) runs during app bootstrap, before `beforeEach()` executes. It also drops `auth:sanctum`/`auth` from the route middleware since Sanctum isn't a project dependency; the controller enforces its own 401/403 via `Auth::user()`, so route-level auth middleware isn't required to test that.
+- **Pest's `uses()` is one-per-directory**: only the root `tests/Pest.php` is loaded (nested `Pest.php` files in subdirectories are not), and a file can't mix two unrelated concrete TestCase classes. If a new test subtree needs a different TestCase, add another `uses(X::class)->in('SomeDir')` line to `tests/Pest.php` rather than dropping a `Pest.php` into that subdirectory.
+- **DB-backed Feature tests**: `tests/TestCase.php` configures an in-memory `testing` sqlite connection. The `users` table isn't provided by any registered migration path in this package's test setup (no `laravel/sanctum`, no workbench migrations wired in) — `tests/Feature/HostpinnacleAccountControllerTest.php` creates it inline with `Schema::create` in `beforeEach()` when missing. Reuse that pattern rather than reaching for `RefreshDatabase`/factories tied to workbench discovery, which isn't set up here.

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0|^8.1|^8.2|^8.3",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "guzzlehttp/guzzle": "^6.0|^7.0"
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "pestphp/pest": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ebeaa155d322a97d208f6d91340a640",
+    "content-hash": "bf72b7e14f0084af21d4812a292c5a06",
     "packages": [
         {
             "name": "brick/math",
@@ -9309,5 +9309,5 @@
         "php": "^7.1|^8.0|^8.1|^8.2|^8.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/hostpinnacle.php
+++ b/config/hostpinnacle.php
@@ -63,11 +63,9 @@ return [
     'saas' => [
         'enabled' => env('HOSTPINNACLE_SAAS_ENABLED', false),
         'table' => 'hostpinnacle_accounts',
-        'owner_type' => env('HOSTPINNACLE_SAAS_OWNER_TYPE', 'user'),
         'owner_key' => env('HOSTPINNACLE_SAAS_OWNER_KEY', 'user_id'),
         'owner_key_type' => env('HOSTPINNACLE_SAAS_OWNER_KEY_TYPE', 'unsignedBigInteger'),
         'owner_model' => env('HOSTPINNACLE_SAAS_OWNER_MODEL', 'App\\Models\\User'),
-        'encrypt_password' => env('HOSTPINNACLE_SAAS_ENCRYPT_PASSWORD', true),
         'api_routes_enabled' => env('HOSTPINNACLE_SAAS_API_ROUTES_ENABLED', true),
         'web_routes_enabled' => env('HOSTPINNACLE_SAAS_WEB_ROUTES_ENABLED', true),
         'api_prefix' => env('HOSTPINNACLE_SAAS_API_PREFIX', 'api'),

--- a/docs/guide/saas-multi-account.md
+++ b/docs/guide/saas-multi-account.md
@@ -45,8 +45,7 @@ See [Config reference](/reference/config) for the full list. Key options:
 |-----|-------------|
 | `saas.enabled` | Turn on multi-account features (migrations, routes, `Hostpinnacle::for()`). |
 | `saas.table` | Table name for accounts (default: `hostpinnacle_accounts`). |
-| `saas.owner_type` / `saas.owner_key` / `saas.owner_key_type` / `saas.owner_model` | Owner of an account; set `owner_key_type` to `uuid` or `string` when the owner model uses a non-integer primary key. |
-| `saas.encrypt_password` | Encrypt password in DB (default: true). |
+| `saas.owner_key` / `saas.owner_key_type` / `saas.owner_model` | Owner of an account; set `owner_key_type` to `uuid` or `string` when the owner model uses a non-integer primary key. |
 | `saas.api_routes_enabled` / `saas.web_routes_enabled` | Enable API and/or Web CRUD routes. |
 | `saas.api_prefix` / `saas.web_prefix` | Route prefixes (e.g. `api`, `hostpinnacle`). |
 | `saas.api_middleware` / `saas.web_middleware` | Middleware for API and Web routes. |
@@ -54,5 +53,5 @@ See [Config reference](/reference/config) for the full list. Key options:
 ## Security (SaaS)
 
 - Use **HTTPS** in production so credentials are not sent in clear text.
-- Passwords are stored encrypted when `saas.encrypt_password` is true.
+- Passwords are always stored encrypted (`HostpinnacleAccount` casts `password` as `encrypted`).
 - Do not log credentials; the package masks `api_key` in API responses and never returns `password`.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -22,11 +22,9 @@
 |-----|-----|---------|-------------|
 | `enabled` | `HOSTPINNACLE_SAAS_ENABLED` | `false` | Turn on multi-account (migrations, routes, `Hostpinnacle::for()`) |
 | `table` | — | `hostpinnacle_accounts` | Table name for stored accounts (set before migrating; do not change after) |
-| `owner_type` | `HOSTPINNACLE_SAAS_OWNER_TYPE` | `user` | Owner type (e.g. user, tenant) |
 | `owner_key` | `HOSTPINNACLE_SAAS_OWNER_KEY` | `user_id` | Owner foreign key column name (set before migrating; do not change after) |
 | `owner_key_type` | `HOSTPINNACLE_SAAS_OWNER_KEY_TYPE` | `unsignedBigInteger` | Owner column type: `unsignedBigInteger`, `uuid`, or `string` (set before migrating; use `uuid` or `string` when owner model has UUID/string PK) |
 | `owner_model` | `HOSTPINNACLE_SAAS_OWNER_MODEL` | `App\Models\User` | Eloquent model for owner relation |
-| `encrypt_password` | `HOSTPINNACLE_SAAS_ENCRYPT_PASSWORD` | `true` | Encrypt password in DB |
 | `api_routes_enabled` | `HOSTPINNACLE_SAAS_API_ROUTES_ENABLED` | `true` | Register API CRUD routes when SaaS enabled |
 | `web_routes_enabled` | `HOSTPINNACLE_SAAS_WEB_ROUTES_ENABLED` | `true` | Register Web CRUD routes when SaaS enabled |
 | `api_prefix` | `HOSTPINNACLE_SAAS_API_PREFIX` | `api` | API route prefix |

--- a/src/Exceptions/IsNullException.php
+++ b/src/Exceptions/IsNullException.php
@@ -2,9 +2,9 @@
 
 namespace Itsmurumba\Hostpinnacle\Exceptions;
 
-use Exception;
+use InvalidArgumentException;
 
 /**
  * Exception thrown when a required value is null (e.g. missing msg or mobile for SMS).
  */
-class IsNullException extends Exception {}
+class IsNullException extends InvalidArgumentException {}

--- a/src/Hostpinnacle.php
+++ b/src/Hostpinnacle.php
@@ -2,7 +2,6 @@
 
 namespace Itsmurumba\Hostpinnacle;
 
-use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Config;
 use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
@@ -15,9 +14,6 @@ class Hostpinnacle
 {
     /** @var string API key from Hostpinnacle Dashboard */
     protected $apiKey;
-
-    /** @var Client Guzzle HTTP client */
-    protected $client;
 
     /** @var mixed Last response from the API */
     protected $response;
@@ -48,46 +44,6 @@ class Hostpinnacle
         $this->username = $creds->getUsername();
         $this->password = $creds->getPassword();
         $this->baseUrl = $creds->getBaseUrl() ?? Config::get('hostpinnacle.baseUrl');
-
-        $this->setRequestOptions();
-    }
-
-    /**
-     * Configure the Guzzle client with base URI and headers.
-     */
-    private function setRequestOptions(): void
-    {
-        $this->client = new Client(
-            [
-                'base_uri' => $this->baseUrl,
-                'headers' => [
-                    'apikey' => $this->apiKey,
-                    'content-type'  => 'application/x-www-form-urlencoded',
-                    'cache-control' => 'no-cache'
-                ]
-            ]
-        );
-    }
-
-    /**
-     * Send an HTTP request and return the response.
-     *
-     * @param  string  $relativeUrl
-     * @param  string  $method
-     * @param  array<string, mixed>  $body
-     * @return \Psr\Http\Message\ResponseInterface
-     * @throws IsNullException
-     */
-    private function setHttpResponse($relativeUrl, $method, $body = [])
-    {
-        if (is_null($method)) {
-            throw new IsNullException('Method must not be null');
-        }
-
-        return $this->client->{strtolower($method)}(
-            $this->baseUrl . $relativeUrl,
-            ["body" => json_encode($body)]
-        );
     }
 
     /**

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('example', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Feature/HostpinnacleAccountControllerTest.php
+++ b/tests/Feature/HostpinnacleAccountControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
+use Workbench\App\Models\User;
+use Workbench\Database\Factories\UserFactory;
+
+beforeEach(function () {
+    if (! Schema::hasTable('users')) {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    $this->artisan('migrate')->run();
+});
+
+function makeHostpinnacleUser(): User
+{
+    return UserFactory::new()->create();
+}
+
+function makeHostpinnacleAccount(int $ownerId, array $overrides = []): HostpinnacleAccount
+{
+    return HostpinnacleAccount::create(array_merge([
+        'user_id' => $ownerId,
+        'api_key' => 'test-api-key-12345',
+        'sender_id' => 'SENDER',
+        'username' => 'user',
+        'password' => 'secret',
+        'name' => 'Test Account',
+    ], $overrides));
+}
+
+test('registers saas api and web routes when saas is enabled', function () {
+    expect(Route::has('hostpinnacle.api.accounts.index'))->toBeTrue();
+    expect(Route::has('hostpinnacle.web.accounts.index'))->toBeTrue();
+});
+
+test('index lists only the current owners accounts as json', function () {
+    $user = makeHostpinnacleUser();
+    $other = makeHostpinnacleUser();
+    makeHostpinnacleAccount($user->id, ['name' => 'Mine']);
+    makeHostpinnacleAccount($other->id, ['name' => 'Not mine']);
+
+    $response = $this->actingAs($user)->getJson('/api/hostpinnacle/accounts');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.name', 'Mine');
+});
+
+test('index requires authentication', function () {
+    $this->getJson('/api/hostpinnacle/accounts')->assertStatus(401);
+});
+
+test('show returns a single owned account', function () {
+    $user = makeHostpinnacleUser();
+    $account = makeHostpinnacleAccount($user->id);
+
+    $response = $this->actingAs($user)->getJson("/api/hostpinnacle/accounts/{$account->id}");
+
+    $response->assertOk();
+    $response->assertJsonPath('data.id', $account->id);
+});
+
+test('show forbids access to another owners account', function () {
+    $user = makeHostpinnacleUser();
+    $owner = makeHostpinnacleUser();
+    $account = makeHostpinnacleAccount($owner->id);
+
+    $this->actingAs($user)->getJson("/api/hostpinnacle/accounts/{$account->id}")->assertStatus(403);
+});
+
+test('store creates an account for the current owner', function () {
+    $user = makeHostpinnacleUser();
+
+    $response = $this->actingAs($user)->postJson('/api/hostpinnacle/accounts', [
+        'api_key' => 'new-api-key-12345',
+        'sender_id' => 'NEWSENDER',
+        'username' => 'newuser',
+        'password' => 'newpass',
+        'name' => 'New Account',
+    ]);
+
+    $response->assertCreated();
+    $response->assertJsonPath('data.name', 'New Account');
+    $this->assertDatabaseHas('hostpinnacle_accounts', [
+        'name' => 'New Account',
+        'user_id' => $user->id,
+    ]);
+});
+
+test('store validates required fields', function () {
+    $user = makeHostpinnacleUser();
+
+    $this->actingAs($user)->postJson('/api/hostpinnacle/accounts', [])
+        ->assertJsonValidationErrors(['api_key', 'sender_id', 'username', 'password']);
+});
+
+test('update modifies an owned account without requiring password', function () {
+    $user = makeHostpinnacleUser();
+    $account = makeHostpinnacleAccount($user->id);
+
+    $response = $this->actingAs($user)->putJson("/api/hostpinnacle/accounts/{$account->id}", [
+        'name' => 'Renamed',
+    ]);
+
+    $response->assertOk();
+    $response->assertJsonPath('data.name', 'Renamed');
+});
+
+test('update forbids modifying another owners account', function () {
+    $user = makeHostpinnacleUser();
+    $owner = makeHostpinnacleUser();
+    $account = makeHostpinnacleAccount($owner->id);
+
+    $this->actingAs($user)->putJson("/api/hostpinnacle/accounts/{$account->id}", ['name' => 'Hijacked'])
+        ->assertStatus(403);
+});
+
+test('destroy deletes an owned account', function () {
+    $user = makeHostpinnacleUser();
+    $account = makeHostpinnacleAccount($user->id);
+
+    $this->actingAs($user)->deleteJson("/api/hostpinnacle/accounts/{$account->id}")->assertOk();
+
+    $this->assertDatabaseMissing('hostpinnacle_accounts', ['id' => $account->id]);
+});
+
+test('destroy forbids deleting another owners account', function () {
+    $user = makeHostpinnacleUser();
+    $owner = makeHostpinnacleUser();
+    $account = makeHostpinnacleAccount($owner->id);
+
+    $this->actingAs($user)->deleteJson("/api/hostpinnacle/accounts/{$account->id}")->assertStatus(403);
+
+    $this->assertDatabaseHas('hostpinnacle_accounts', ['id' => $account->id]);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,9 +11,11 @@
 |
 */
 
+use Itsmurumba\Hostpinnacle\Tests\Support\SaasEnabledTestCase;
 use Itsmurumba\Hostpinnacle\Tests\TestCase;
 
-uses(TestCase::class)->in('Feature', 'Unit');
+uses(TestCase::class)->in('Unit');
+uses(SaasEnabledTestCase::class)->in('Feature');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Support/SaasEnabledTestCase.php
+++ b/tests/Support/SaasEnabledTestCase.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Tests\Support;
+
+use Itsmurumba\Hostpinnacle\Tests\TestCase;
+
+/**
+ * TestCase with SaaS mode enabled at boot time, so the package's conditional
+ * migrations/routes (registered in HostpinnacleServiceProvider::boot) load.
+ *
+ * Drops auth:sanctum/auth from the route middleware since Sanctum isn't a
+ * project dependency; HostpinnacleAccountController enforces its own 401/403
+ * checks via Auth::user(), so route-level auth middleware isn't required for
+ * that to be testable.
+ */
+class SaasEnabledTestCase extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('hostpinnacle.saas.enabled', true);
+        $app['config']->set('hostpinnacle.saas.owner_model', 'Workbench\\App\\Models\\User');
+        $app['config']->set('hostpinnacle.saas.api_middleware', ['api']);
+        $app['config']->set('hostpinnacle.saas.web_middleware', ['web']);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,17 +8,6 @@ use Orchestra\Testbench\TestCase as TestbenchTestCase;
 
 class TestCase extends TestbenchTestCase
 {
-
-    protected $hostpinnacle;
-    protected $mock;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->hostpinnacle = Mockery::mock('Itsmurumba\Hostpinnacle\Hostpinnacle');
-        $this->mock = Mockery::mock('GuzzleHttp\Client');
-    }
-
     protected function getPackageProviders($app)
     {
         return [
@@ -29,6 +18,12 @@ class TestCase extends TestbenchTestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('app.key', 'base64:' . base64_encode(\Illuminate\Support\Str::random(32)));
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
     }
 
     protected function tearDown(): void

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('example', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Unit/Hostpinnacle/HostpinnacleAccountResourceTest.php
+++ b/tests/Unit/Hostpinnacle/HostpinnacleAccountResourceTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Http\Request;
+use Itsmurumba\Hostpinnacle\Http\Resources\HostpinnacleAccountResource;
+use Itsmurumba\Hostpinnacle\Models\HostpinnacleAccount;
+
+test('toArray masks the api_key and never exposes the password', function () {
+    $account = new HostpinnacleAccount([
+        'api_key' => 'abcd1234wxyz',
+        'sender_id' => 'SENDER',
+        'username' => 'user',
+        'password' => 'secret',
+        'base_url' => 'https://api.test',
+        'name' => 'Test Account',
+    ]);
+
+    $array = (new HostpinnacleAccountResource($account))->toArray(new Request());
+
+    expect($array['api_key'])->toBe('abcd****wxyz')
+        ->and($array['name'])->toBe('Test Account')
+        ->and($array['sender_id'])->toBe('SENDER')
+        ->and($array)->not->toHaveKey('password');
+});
+
+test('toArray fully masks a short api_key', function () {
+    $account = new HostpinnacleAccount([
+        'api_key' => 'short',
+        'sender_id' => 'SENDER',
+        'username' => 'user',
+        'password' => 'secret',
+    ]);
+
+    $array = (new HostpinnacleAccountResource($account))->toArray(new Request());
+
+    expect($array['api_key'])->toBe('*****');
+});
+
+test('toArray returns null api_key when none is set', function () {
+    $account = new HostpinnacleAccount([
+        'api_key' => '',
+        'sender_id' => 'SENDER',
+        'username' => 'user',
+        'password' => 'secret',
+    ]);
+
+    $array = (new HostpinnacleAccountResource($account))->toArray(new Request());
+
+    expect($array['api_key'])->toBeNull();
+});

--- a/tests/Unit/Hostpinnacle/HostpinnacleCredentialsTest.php
+++ b/tests/Unit/Hostpinnacle/HostpinnacleCredentialsTest.php
@@ -5,6 +5,63 @@ use Itsmurumba\Hostpinnacle\Hostpinnacle;
 use Itsmurumba\Hostpinnacle\HostpinnacleCredentials;
 use Illuminate\Support\Facades\Http;
 
+test('fromArray accepts snake_case keys', function () {
+    $credentials = HostpinnacleCredentials::fromArray([
+        'api_key' => 'snake-key',
+        'sender_id' => 'SNAKEID',
+        'username' => 'snakeuser',
+        'password' => 'snakepass',
+        'base_url' => 'https://snake.test',
+    ]);
+
+    expect($credentials->getApiKey())->toBe('snake-key')
+        ->and($credentials->getSenderId())->toBe('SNAKEID')
+        ->and($credentials->getBaseUrl())->toBe('https://snake.test');
+});
+
+test('fromArray accepts camelCase keys', function () {
+    $credentials = HostpinnacleCredentials::fromArray([
+        'apiKey' => 'camel-key',
+        'senderId' => 'CAMELID',
+        'username' => 'cameluser',
+        'password' => 'camelpass',
+        'baseUrl' => 'https://camel.test',
+    ]);
+
+    expect($credentials->getApiKey())->toBe('camel-key')
+        ->and($credentials->getSenderId())->toBe('CAMELID')
+        ->and($credentials->getBaseUrl())->toBe('https://camel.test');
+});
+
+test('fromArray prefers snake_case over camelCase when both are given', function () {
+    $credentials = HostpinnacleCredentials::fromArray([
+        'api_key' => 'snake-key',
+        'apiKey' => 'camel-key',
+        'sender_id' => 'SNAKEID',
+        'senderId' => 'CAMELID',
+        'username' => 'user',
+        'password' => 'pass',
+        'base_url' => 'https://snake.test',
+        'baseUrl' => 'https://camel.test',
+    ]);
+
+    expect($credentials->getApiKey())->toBe('snake-key')
+        ->and($credentials->getSenderId())->toBe('SNAKEID')
+        ->and($credentials->getBaseUrl())->toBe('https://snake.test');
+});
+
+test('fromArray treats an empty base_url as null', function () {
+    $credentials = HostpinnacleCredentials::fromArray([
+        'api_key' => 'key',
+        'sender_id' => 'ID',
+        'username' => 'user',
+        'password' => 'pass',
+        'base_url' => '',
+    ]);
+
+    expect($credentials->getBaseUrl())->toBeNull();
+});
+
 beforeEach(function () {
     hostpinnacle_set_config();
 });

--- a/tests/Unit/Hostpinnacle/HostpinnacleFactoryTest.php
+++ b/tests/Unit/Hostpinnacle/HostpinnacleFactoryTest.php
@@ -69,6 +69,3 @@ test('HostpinnacleFactory for HostpinnacleAccount returns Hostpinnacle using acc
             && $request->hasHeader('apikey', 'account-key');
     });
 });
-
-// Hostpinnacle::for($account) is a thin wrapper around app(HostpinnacleFactory::class)->for($account);
-// and is covered by the factory tests above.

--- a/tests/Unit/Hostpinnacle/HostpinnacleServiceProviderTest.php
+++ b/tests/Unit/Hostpinnacle/HostpinnacleServiceProviderTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\HostpinnacleFactory;
+
+test('merges the default hostpinnacle config', function () {
+    expect(config('hostpinnacle.saas.table'))->toBe('hostpinnacle_accounts')
+        ->and(config('hostpinnacle.saas.owner_key'))->toBe('user_id')
+        ->and(config('hostpinnacle.saas.enabled'))->toBeFalse();
+});
+
+test('binds the hostpinnacle singleton and its alias', function () {
+    $hostpinnacle = app('hostpinnacle');
+
+    expect($hostpinnacle)->toBeInstanceOf(Hostpinnacle::class)
+        ->and(app('hostpinnacle'))->toBe($hostpinnacle)
+        ->and(app('laravel-hostpinnacle'))->toBe($hostpinnacle);
+});
+
+test('binds the HostpinnacleFactory singleton', function () {
+    $factory = app(HostpinnacleFactory::class);
+
+    expect($factory)->toBeInstanceOf(HostpinnacleFactory::class)
+        ->and(app(HostpinnacleFactory::class))->toBe($factory);
+});
+
+test('does not register saas routes when saas is disabled', function () {
+    expect(Route::has('hostpinnacle.api.accounts.index'))->toBeFalse()
+        ->and(Route::has('hostpinnacle.web.accounts.index'))->toBeFalse();
+});

--- a/tests/Unit/HostpinnacleFacadeTest.php
+++ b/tests/Unit/HostpinnacleFacadeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Itsmurumba\Hostpinnacle\Facades\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Hostpinnacle as HostpinnacleClient;
+use Itsmurumba\Hostpinnacle\HostpinnacleCredentials;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('facade proxies sendQuickSMS to the bound singleton', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = Hostpinnacle::sendQuickSMS([
+        'msg' => 'Hello World',
+        'mobile' => '254700000000',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->hasHeader('apikey', 'test-api-key')
+            && $request['msg'] === 'Hello World';
+    });
+});
+
+test('facade for() builds a Hostpinnacle client from the given credentials', function () {
+    Http::fake([
+        'https://facade-api.test/send*' => Http::response(['status' => 'ok'], 200),
+    ]);
+
+    $credentials = new HostpinnacleCredentials(
+        'facade-key',
+        'FID',
+        'facadeuser',
+        'facadepass',
+        'https://facade-api.test'
+    );
+
+    $client = Hostpinnacle::for($credentials);
+
+    expect($client)->toBeInstanceOf(HostpinnacleClient::class);
+
+    $client->sendQuickSMS(['msg' => 'Hi', 'mobile' => '254700000000']);
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), 'https://facade-api.test')
+            && $request->hasHeader('apikey', 'facade-key');
+    });
+});


### PR DESCRIPTION
## Summary

Three-part pass over the package, done in order since the cleanup changes what the tests needed to cover:

- **Cleanup** (over-engineering audit findings): removed the dead Guzzle client path in `Hostpinnacle.php` (every real request already goes through the `Http` facade) and the now-unused direct `guzzlehttp/guzzle` composer dependency; `IsNullException` now extends `InvalidArgumentException` instead of a bare `Exception` (no BC break — same class/name/call sites); removed dead Mockery scaffolding from `tests/TestCase.php`; removed `saas.owner_type`/`saas.encrypt_password` config keys (and their docs rows) since no code path reads them; deleted the two leftover Pest skeleton placeholder tests.
- **Test coverage**: added tests for `HostpinnacleAccountController` (full CRUD + 401/403 authorization, `tests/Feature/`), the `Hostpinnacle` facade, `HostpinnacleAccountResource` (api_key masking), `HostpinnacleServiceProvider` (config merge, bindings, conditional SaaS route registration), and `HostpinnacleCredentials::fromArray` (snake_case/camelCase precedence). Suite went from 28 to 52 passing tests.
- **`CLAUDE.md`**: architecture map, conventions, commands, and testing patterns/gotchas for future agent work in this repo.

## Test plan

- [x] `composer test` — 52 passed (116 assertions)
- [x] `composer validate` — composer.json/lock valid after dropping the direct guzzlehttp/guzzle require
- [x] Manually confirmed `vendor/guzzlehttp` is still present (pulled in transitively via `illuminate/http`)