### PR TITLE
Phase 0: fix Group SMS GET/POST bug, add smartlink support

### DIFF
--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -33,6 +33,19 @@ $data['msg'] = 'Hello World!';
 $response = $this->hostpinnacle->sendQuickSMS($data);
 ```
 
+**Send quick SMS with link tracking (smartlink):**
+
+`sendQuickSMS`, `sendGroupSMS`, and `sendMobileOnlyFileSMS` accept optional `trackLink` and
+`smartLinkTitle` keys to enable link tracking on any link in the message:
+
+```php
+$data['mobile'] = '254720xxxxxx';
+$data['msg'] = 'Check out https://example.com';
+$data['trackLink'] = 'true';
+$data['smartLinkTitle'] = 'My Example.com Short Link';
+$response = $this->hostpinnacle->sendQuickSMS($data);
+```
+
 **Send quick scheduled SMS:**
 
 ```php

--- a/src/Hostpinnacle.php
+++ b/src/Hostpinnacle.php
@@ -53,9 +53,11 @@ class Hostpinnacle
      * @param  string|null  $groupIds
      * @param  mixed  $file
      * @param  string|null  $scheduled
+     * @param  string|null  $trackLink  Enable link tracking (smartlink)
+     * @param  string|null  $smartLinkTitle  Title to identify the tracked link
      * @return array<string, mixed>
      */
-    private function formattedSmsData(string $sendMethod, ?string $message, string $messageType, $contacts = null, $groupIds = null, $file = null, $scheduled = null): array
+    private function formattedSmsData(string $sendMethod, ?string $message, string $messageType, $contacts = null, $groupIds = null, $file = null, $scheduled = null, $trackLink = null, $smartLinkTitle = null): array
     {
         $data = array_filter([
             "userid" => $this->username,
@@ -80,13 +82,22 @@ class Hostpinnacle
             $data["scheduleTime"] = $scheduled;
         }
 
+        if ($trackLink != null) {
+            $data["trackLink"] = $trackLink;
+        }
+
+        if ($smartLinkTitle != null) {
+            $data["smartLinkTitle"] = $smartLinkTitle;
+        }
+
         return $data;
     }
 
     /**
      * Send quick SMS in batches (single or comma-separated mobiles). Country code required for international.
+     * Pass trackLink/smartLinkTitle to enable link tracking (smartlink) on links in the message.
      *
-     * @param  array{msg: string, mobile: string}  $data
+     * @param  array{msg: string, mobile: string, trackLink?: string, smartLinkTitle?: string}  $data
      * @return \Illuminate\Http\Client\Response
      * @throws IsNullException
      */
@@ -96,7 +107,17 @@ class Hostpinnacle
             throw new IsNullException('msg and mobile must not be null');
         }
 
-        $payload = $this->formattedSmsData('quick', $data['msg'], 'text', $data['mobile']);
+        $payload = $this->formattedSmsData(
+            'quick',
+            $data['msg'],
+            'text',
+            $data['mobile'],
+            null,
+            null,
+            null,
+            $data['trackLink'] ?? null,
+            $data['smartLinkTitle'] ?? null
+        );
 
         return Http::asForm()->withHeaders([
             'apikey' => $this->apiKey,
@@ -133,8 +154,9 @@ class Hostpinnacle
 
     /**
      * Send SMS to one or more groups (single or comma-separated group IDs). Country code required for international.
+     * Pass trackLink/smartLinkTitle to enable link tracking (smartlink) on links in the message.
      *
-     * @param  array{msg: string, groupIds: string}  $data
+     * @param  array{msg: string, groupIds: string, trackLink?: string, smartLinkTitle?: string}  $data
      * @return \Illuminate\Http\Client\Response
      * @throws IsNullException
      */
@@ -144,12 +166,22 @@ class Hostpinnacle
             throw new IsNullException('msg and groupIds must not be null');
         }
 
-        $payload = $this->formattedSmsData('group', $data['msg'], 'text', null, $data['groupIds']);
+        $payload = $this->formattedSmsData(
+            'group',
+            $data['msg'],
+            'text',
+            null,
+            $data['groupIds'],
+            null,
+            null,
+            $data['trackLink'] ?? null,
+            $data['smartLinkTitle'] ?? null
+        );
 
         return Http::asForm()->withHeaders([
             'apikey' => $this->apiKey,
             'cache-control' => 'no-cache'
-        ])->get(
+        ])->post(
             $this->baseUrl . '/send',
             $payload
         );
@@ -173,7 +205,7 @@ class Hostpinnacle
         return Http::asForm()->withHeaders([
             'apikey' => $this->apiKey,
             'cache-control' => 'no-cache'
-        ])->get(
+        ])->post(
             $this->baseUrl . '/send',
             $payload
         );
@@ -181,8 +213,9 @@ class Hostpinnacle
 
     /**
      * Send SMS from file with mobile numbers only (first row header: Phone). Country code required e.g. 254720000000.
+     * Pass trackLink/smartLinkTitle to enable link tracking (smartlink) on links in the message.
      *
-     * @param  array{msg: string, file: \Illuminate\Http\UploadedFile|object}  $data
+     * @param  array{msg: string, file: \Illuminate\Http\UploadedFile|object, trackLink?: string, smartLinkTitle?: string}  $data
      * @return \Illuminate\Http\Client\Response
      * @throws IsNullException
      */
@@ -192,7 +225,17 @@ class Hostpinnacle
             throw new IsNullException('msg and file must not be null');
         }
 
-        $payload = $this->formattedSmsData('bulkupload', $data['msg'], 'text');
+        $payload = $this->formattedSmsData(
+            'bulkupload',
+            $data['msg'],
+            'text',
+            null,
+            null,
+            null,
+            null,
+            $data['trackLink'] ?? null,
+            $data['smartLinkTitle'] ?? null
+        );
 
         $extension = $data['file']->getClientOriginalExtension();
 

--- a/tests/Unit/Hostpinnacle/SendGroupSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendGroupSMSTest.php
@@ -8,7 +8,7 @@ beforeEach(function () {
     hostpinnacle_set_config();
 });
 
-test('sends get request with group ids', function () {
+test('sends post request with group ids', function () {
     Http::fake([
         'https://api.hostpinnacle.test/send*' => Http::response(['status' => 'success'], 200),
     ]);
@@ -21,8 +21,29 @@ test('sends get request with group ids', function () {
 
     expect($response->successful())->toBeTrue();
     Http::assertSent(function ($request) {
-        return str_contains($request->url(), 'https://api.hostpinnacle.test/send')
-            && $request->hasHeader('apikey', 'test-api-key');
+        return $request->method() === 'POST'
+            && str_contains($request->url(), 'https://api.hostpinnacle.test/send')
+            && $request->hasHeader('apikey', 'test-api-key')
+            && $request['group'] === '1,2,3';
+    });
+});
+
+test('sends trackLink and smartLinkTitle when provided', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $hostpinnacle = new Hostpinnacle();
+    $hostpinnacle->sendGroupSMS([
+        'msg' => 'Check out https://example.com',
+        'groupIds' => '1,2,3',
+        'trackLink' => 'true',
+        'smartLinkTitle' => 'My Example Link',
+    ]);
+
+    Http::assertSent(function ($request) {
+        return $request['trackLink'] === 'true'
+            && $request['smartLinkTitle'] === 'My Example Link';
     });
 });
 

--- a/tests/Unit/Hostpinnacle/SendGroupScheduledSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendGroupScheduledSMSTest.php
@@ -8,7 +8,7 @@ beforeEach(function () {
     hostpinnacle_set_config();
 });
 
-test('sends get request with scheduleTime', function () {
+test('sends post request with scheduleTime', function () {
     Http::fake([
         'https://api.hostpinnacle.test/send*' => Http::response(['status' => 'success'], 200),
     ]);
@@ -21,6 +21,10 @@ test('sends get request with scheduleTime', function () {
     ]);
 
     expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->method() === 'POST'
+            && $request['scheduleTime'] === '2025-02-02 12:00:00';
+    });
 });
 
 test('throws IsNullException when required params missing', function () {

--- a/tests/Unit/Hostpinnacle/SendMobileOnlyFileSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendMobileOnlyFileSMSTest.php
@@ -24,6 +24,27 @@ test('sends post with file attachment', function () {
     $file->close();
 });
 
+test('sends trackLink and smartLinkTitle when provided', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $file = hostpinnacle_mock_file("Phone\n254700000000\n");
+    $hostpinnacle = new Hostpinnacle();
+    $hostpinnacle->sendMobileOnlyFileSMS([
+        'msg' => 'Check out https://example.com',
+        'file' => $file,
+        'trackLink' => 'true',
+        'smartLinkTitle' => 'My Example Link',
+    ]);
+    $file->close();
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->body(), "name=\"trackLink\"\r\nContent-Length: 4\r\n\r\ntrue\r\n")
+            && str_contains($request->body(), "name=\"smartLinkTitle\"\r\nContent-Length: 15\r\n\r\nMy Example Link\r\n");
+    });
+});
+
 test('throws IsNullException when msg is missing', function () {
     $hostpinnacle = new Hostpinnacle();
     $file = new class {

--- a/tests/Unit/Hostpinnacle/SendQuickSMSTest.php
+++ b/tests/Unit/Hostpinnacle/SendQuickSMSTest.php
@@ -28,6 +28,41 @@ test('sends post request with correct payload', function () {
     });
 });
 
+test('sends trackLink and smartLinkTitle when provided', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $hostpinnacle = new Hostpinnacle();
+    $hostpinnacle->sendQuickSMS([
+        'msg' => 'Check out https://example.com',
+        'mobile' => '254700000000',
+        'trackLink' => 'true',
+        'smartLinkTitle' => 'My Example Link',
+    ]);
+
+    Http::assertSent(function ($request) {
+        return $request['trackLink'] === 'true'
+            && $request['smartLinkTitle'] === 'My Example Link';
+    });
+});
+
+test('omits trackLink and smartLinkTitle when not provided', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/send' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $hostpinnacle = new Hostpinnacle();
+    $hostpinnacle->sendQuickSMS([
+        'msg' => 'Hello World',
+        'mobile' => '254700000000',
+    ]);
+
+    Http::assertSent(function ($request) {
+        return !isset($request['trackLink']) && !isset($request['smartLinkTitle']);
+    });
+});
+
 test('throws IsNullException when msg is missing', function () {
     $hostpinnacle = new Hostpinnacle();
 


### PR DESCRIPTION
## Summary

Phase 0 of the [API coverage roadmap](docs/contributing/api-coverage-roadmap.md) (#7):

- **Bugfix:** `sendGroupSMS`/`sendGroupScheduledSMS` sent as HTTP GET; the Hostpinnacle API documents Group SMS as POST with a form body (confirmed against the official Postman collection). Both now POST, matching `sendQuickSMS`.
- **Smartlink:** `sendQuickSMS`, `sendGroupSMS`, and `sendMobileOnlyFileSMS` accept optional `trackLink`/`smartLinkTitle` keys to enable link tracking — no new methods, just optional keys on the existing `$data` array (per the roadmap's decision to avoid near-duplicate `*SmartlinkSMS` methods).
- Docs: added a smartlink example to `docs/guide/usage.md`.

Note: the roadmap doc listed introducing `Api\BaseApiClient` as part of Phase 0. Deferred that to Phase 1, where `ScheduleClient` is its first real consumer — building it now would be scaffolding with no caller yet.

## Test plan

- [x] `composer test` — 56 passed (121 assertions), up from 52
- [x] New coverage: POST assertions for both Group SMS methods, trackLink/smartLinkTitle sent when provided (form-encoded and multipart), and omitted when not provided