### PR TITLE
Phase 2: setup resources (SenderId, MessageTemplate, Draft)

### DIFF
--- a/docs/contributing/api-coverage-roadmap.md
+++ b/docs/contributing/api-coverage-roadmap.md
@@ -23,9 +23,9 @@ the order it'll ship in.
 | File upload (mobile + message) | Send | ✅ `Hostpinnacle::sendMobileAndMessageFileSMS()` |
 | | Send (scheduled) | ✅ `Hostpinnacle::sendMobileAndMessageFileScheduledSMS()` |
 | Schedule | Read / Update / Delete | ✅ `Hostpinnacle::schedule()->read()/update()/delete()` |
-| Sender ID | Create / Read / Update / Delete | 🔜 Phase 2 |
-| Message Template | Create / Read / Update / Delete | 🔜 Phase 2 |
-| Draft | Create / Read / Update / Delete | 🔜 Phase 2 |
+| Sender ID | Create / Read / Update / Delete | ✅ `Hostpinnacle::senderId()->create()/read()/update()/delete()` |
+| Message Template | Create / Read / Update / Delete | ✅ `Hostpinnacle::messageTemplate()->create()/read()/update()/delete()` |
+| Draft | Create / Read / Update / Delete | ✅ `Hostpinnacle::draft()->create()/read()/update()/delete()` |
 | Webhook | Create / Read / Update / Delete | 🔜 Phase 3 |
 | Account profile | Read status / Read profile / Update profile / Read credit history | 🔜 Phase 3 |
 | Password | Change | 🔜 Phase 3 |

--- a/src/Api/BaseApiClient.php
+++ b/src/Api/BaseApiClient.php
@@ -43,4 +43,24 @@ abstract class BaseApiClient
             'cache-control' => 'no-cache',
         ])->post($this->baseUrl . $endpoint, $payload);
     }
+
+    /**
+     * GET $endpoint with the shared userid/password/output=json fields merged in as query params.
+     *
+     * @param  array<string, mixed>  $query
+     * @return \Illuminate\Http\Client\Response
+     */
+    protected function get(string $endpoint, array $query = [])
+    {
+        $payload = array_merge([
+            'userid' => $this->credentials->getUsername(),
+            'password' => $this->credentials->getPassword(),
+            'output' => 'json',
+        ], $query);
+
+        return Http::withHeaders([
+            'apikey' => $this->credentials->getApiKey(),
+            'cache-control' => 'no-cache',
+        ])->get($this->baseUrl . $endpoint, $payload);
+    }
 }

--- a/src/Api/DraftClient.php
+++ b/src/Api/DraftClient.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Api;
+
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+
+/**
+ * Draft domain: saved title/content pairs to send later.
+ */
+class DraftClient extends BaseApiClient
+{
+    /**
+     * Create a draft.
+     *
+     * @param  array{title: string, content: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function create($data)
+    {
+        if (!isset($data['title']) || !isset($data['content'])) {
+            throw new IsNullException('title and content must not be null');
+        }
+
+        return $this->post('/draft/create', [
+            'title' => $data['title'],
+            'content' => $data['content'],
+        ]);
+    }
+
+    /**
+     * List drafts on the account.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function read()
+    {
+        return $this->get('/draft/read');
+    }
+
+    /**
+     * Update an existing draft.
+     *
+     * @param  array{title: string, content: string, id: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function update($data)
+    {
+        if (!isset($data['title']) || !isset($data['content']) || !isset($data['id'])) {
+            throw new IsNullException('title, content and id must not be null');
+        }
+
+        return $this->post('/draft/update', [
+            'title' => $data['title'],
+            'content' => $data['content'],
+            'id' => $data['id'],
+        ]);
+    }
+
+    /**
+     * Delete one or more drafts by id (comma-separated).
+     *
+     * @param  array{id: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function delete($data)
+    {
+        if (!isset($data['id'])) {
+            throw new IsNullException('id must not be null');
+        }
+
+        return $this->post('/draft/delete', [
+            'id' => $data['id'],
+        ]);
+    }
+}

--- a/src/Api/MessageTemplateClient.php
+++ b/src/Api/MessageTemplateClient.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Api;
+
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+
+/**
+ * Message Template domain: reusable message bodies for sending.
+ */
+class MessageTemplateClient extends BaseApiClient
+{
+    /**
+     * Create a message template.
+     *
+     * @param  array{message: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function create($data)
+    {
+        if (!isset($data['message'])) {
+            throw new IsNullException('message must not be null');
+        }
+
+        return $this->post('/template/create', [
+            'message' => $data['message'],
+        ]);
+    }
+
+    /**
+     * List message templates on the account.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function read()
+    {
+        return $this->get('/template/read');
+    }
+
+    /**
+     * Update an existing message template.
+     *
+     * @param  array{message: string, id: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function update($data)
+    {
+        if (!isset($data['message']) || !isset($data['id'])) {
+            throw new IsNullException('message and id must not be null');
+        }
+
+        return $this->post('/template/update', [
+            'message' => $data['message'],
+            'id' => $data['id'],
+        ]);
+    }
+
+    /**
+     * Delete one or more message templates by id (comma-separated).
+     *
+     * @param  array{id: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function delete($data)
+    {
+        if (!isset($data['id'])) {
+            throw new IsNullException('id must not be null');
+        }
+
+        return $this->post('/template/delete', [
+            'id' => $data['id'],
+        ]);
+    }
+}

--- a/src/Api/SenderIdClient.php
+++ b/src/Api/SenderIdClient.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Api;
+
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+
+/**
+ * Sender ID domain: manage the approved sender names available to the account.
+ */
+class SenderIdClient extends BaseApiClient
+{
+    /**
+     * Request a new sender ID.
+     *
+     * @param  array{senderid: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function create($data)
+    {
+        if (!isset($data['senderid'])) {
+            throw new IsNullException('senderid must not be null');
+        }
+
+        return $this->post('/senderid/create', [
+            'senderid' => $data['senderid'],
+        ]);
+    }
+
+    /**
+     * List sender IDs on the account.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function read()
+    {
+        return $this->get('/senderid/read');
+    }
+
+    /**
+     * Rename an existing sender ID.
+     *
+     * @param  array{senderid: string, id: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function update($data)
+    {
+        if (!isset($data['senderid']) || !isset($data['id'])) {
+            throw new IsNullException('senderid and id must not be null');
+        }
+
+        return $this->post('/senderid/update', [
+            'senderid' => $data['senderid'],
+            'id' => $data['id'],
+        ]);
+    }
+
+    /**
+     * Delete one or more sender IDs, by id or by sender name (comma-separated).
+     *
+     * @param  array{id?: string, senderid?: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function delete($data)
+    {
+        if (!isset($data['id']) && !isset($data['senderid'])) {
+            throw new IsNullException('id or senderid must not be null');
+        }
+
+        return $this->post('/senderid/delete', array_filter([
+            'id' => $data['id'] ?? null,
+            'senderid' => $data['senderid'] ?? null,
+        ]));
+    }
+}

--- a/src/Hostpinnacle.php
+++ b/src/Hostpinnacle.php
@@ -68,6 +68,36 @@ class Hostpinnacle
     }
 
     /**
+     * Access the Sender ID API (create/read/update/delete approved sender names).
+     *
+     * @return \Itsmurumba\Hostpinnacle\Api\SenderIdClient
+     */
+    public function senderId(): Api\SenderIdClient
+    {
+        return new Api\SenderIdClient($this->credentials);
+    }
+
+    /**
+     * Access the Message Template API (create/read/update/delete reusable message bodies).
+     *
+     * @return \Itsmurumba\Hostpinnacle\Api\MessageTemplateClient
+     */
+    public function messageTemplate(): Api\MessageTemplateClient
+    {
+        return new Api\MessageTemplateClient($this->credentials);
+    }
+
+    /**
+     * Access the Draft API (create/read/update/delete saved title/content drafts).
+     *
+     * @return \Itsmurumba\Hostpinnacle\Api\DraftClient
+     */
+    public function draft(): Api\DraftClient
+    {
+        return new Api\DraftClient($this->credentials);
+    }
+
+    /**
      * Build the payload array for Send SMS Batch, Group, or File requests.
      *
      * @param  string|null  $contacts

--- a/tests/Unit/Api/DraftClientTest.php
+++ b/tests/Unit/Api/DraftClientTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Api\DraftClient;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('draft() returns a DraftClient', function () {
+    expect((new Hostpinnacle())->draft())->toBeInstanceOf(DraftClient::class);
+});
+
+test('create() sends post request with title and content', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/draft/create' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->draft()->create([
+        'title' => 'This is a new draft title.',
+        'content' => 'This is a new draft content.',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/draft/create'
+            && $request->method() === 'POST'
+            && $request['title'] === 'This is a new draft title.'
+            && $request['content'] === 'This is a new draft content.'
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('create() throws IsNullException when title or content missing', function () {
+    (new Hostpinnacle())->draft()->create(['title' => 'Only title']);
+})->throws(IsNullException::class, 'title and content must not be null');
+
+test('read() sends get request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/draft/read*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->draft()->read();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->method() === 'GET'
+            && str_contains($request->url(), 'https://api.hostpinnacle.test/draft/read');
+    });
+});
+
+test('update() sends post request with title, content and id', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/draft/update' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->draft()->update([
+        'title' => 'Title to modify',
+        'content' => 'Modify my existing draft',
+        'id' => '15',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/draft/update'
+            && $request->method() === 'POST'
+            && $request['title'] === 'Title to modify'
+            && $request['content'] === 'Modify my existing draft'
+            && $request['id'] === '15';
+    });
+});
+
+test('update() throws IsNullException when title, content, or id missing', function () {
+    (new Hostpinnacle())->draft()->update(['title' => 'Title', 'content' => 'Content']);
+})->throws(IsNullException::class, 'title, content and id must not be null');
+
+test('delete() sends post request with id', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/draft/delete' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->draft()->delete(['id' => '15,121']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/draft/delete'
+            && $request->method() === 'POST'
+            && $request['id'] === '15,121';
+    });
+});
+
+test('delete() throws IsNullException when id missing', function () {
+    (new Hostpinnacle())->draft()->delete([]);
+})->throws(IsNullException::class, 'id must not be null');

--- a/tests/Unit/Api/MessageTemplateClientTest.php
+++ b/tests/Unit/Api/MessageTemplateClientTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Api\MessageTemplateClient;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('messageTemplate() returns a MessageTemplateClient', function () {
+    expect((new Hostpinnacle())->messageTemplate())->toBeInstanceOf(MessageTemplateClient::class);
+});
+
+test('create() sends post request with message', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/template/create' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->messageTemplate()->create([
+        'message' => 'This is test message ###123### from Test',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/template/create'
+            && $request->method() === 'POST'
+            && $request['message'] === 'This is test message ###123### from Test'
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('create() throws IsNullException when message is missing', function () {
+    (new Hostpinnacle())->messageTemplate()->create([]);
+})->throws(IsNullException::class, 'message must not be null');
+
+test('read() sends get request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/template/read*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->messageTemplate()->read();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->method() === 'GET'
+            && str_contains($request->url(), 'https://api.hostpinnacle.test/template/read');
+    });
+});
+
+test('update() sends post request with message and id', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/template/update' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->messageTemplate()->update([
+        'message' => 'This is test message to update or modify',
+        'id' => '2',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/template/update'
+            && $request->method() === 'POST'
+            && $request['message'] === 'This is test message to update or modify'
+            && $request['id'] === '2';
+    });
+});
+
+test('update() throws IsNullException when message or id missing', function () {
+    (new Hostpinnacle())->messageTemplate()->update(['message' => 'Only message']);
+})->throws(IsNullException::class, 'message and id must not be null');
+
+test('delete() sends post request with id', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/template/delete' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->messageTemplate()->delete(['id' => '2,1']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/template/delete'
+            && $request->method() === 'POST'
+            && $request['id'] === '2,1';
+    });
+});
+
+test('delete() throws IsNullException when id missing', function () {
+    (new Hostpinnacle())->messageTemplate()->delete([]);
+})->throws(IsNullException::class, 'id must not be null');

--- a/tests/Unit/Api/SenderIdClientTest.php
+++ b/tests/Unit/Api/SenderIdClientTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Api\SenderIdClient;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('senderId() returns a SenderIdClient', function () {
+    expect((new Hostpinnacle())->senderId())->toBeInstanceOf(SenderIdClient::class);
+});
+
+test('create() sends post request with senderid', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/senderid/create' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->senderId()->create(['senderid' => 'MYBRAND']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/senderid/create'
+            && $request->method() === 'POST'
+            && $request['userid'] === 'testuser'
+            && $request['senderid'] === 'MYBRAND'
+            && $request['output'] === 'json'
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('create() throws IsNullException when senderid is missing', function () {
+    (new Hostpinnacle())->senderId()->create([]);
+})->throws(IsNullException::class, 'senderid must not be null');
+
+test('read() sends get request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/senderid/read*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->senderId()->read();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->method() === 'GET'
+            && str_contains($request->url(), 'https://api.hostpinnacle.test/senderid/read')
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('update() sends post request with senderid and id', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/senderid/update' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->senderId()->update(['senderid' => 'NEWBRAND', 'id' => '69']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/senderid/update'
+            && $request->method() === 'POST'
+            && $request['senderid'] === 'NEWBRAND'
+            && $request['id'] === '69';
+    });
+});
+
+test('update() throws IsNullException when senderid or id missing', function () {
+    (new Hostpinnacle())->senderId()->update(['senderid' => 'NEWBRAND']);
+})->throws(IsNullException::class, 'senderid and id must not be null');
+
+test('delete() sends post request with id', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/senderid/delete' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->senderId()->delete(['id' => '61,68']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/senderid/delete'
+            && $request->method() === 'POST'
+            && $request['id'] === '61,68';
+    });
+});
+
+test('delete() sends post request with senderid', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/senderid/delete' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->senderId()->delete(['senderid' => 'ABCDEF1,ABCDEF2']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request['senderid'] === 'ABCDEF1,ABCDEF2' && !isset($request['id']);
+    });
+});
+
+test('delete() throws IsNullException when both id and senderid are missing', function () {
+    (new Hostpinnacle())->senderId()->delete([]);
+})->throws(IsNullException::class, 'id or senderid must not be null');


### PR DESCRIPTION
## Summary
- Adds `Api\SenderIdClient`, `Api\MessageTemplateClient`, `Api\DraftClient` (create/read/update/delete each, 12 endpoints total), reached via `Hostpinnacle::senderId()`, `::messageTemplate()`, `::draft()`.
- Extends `Api\BaseApiClient` with a `get()` helper alongside `post()` — these domains' Read endpoints are GET with query params, unlike Phase 1's Schedule domain (all POST).
- Marks Sender ID / Message Template / Draft as ✅ done in the API coverage roadmap.

Field requirements per method follow the Postman collection samples exactly (`docs/contributing/postman/`) — e.g. `senderid`+`id` required together for `SenderIdClient::update()`, matching the collection's Update SenderId request body.

## Test plan
- [x] `composer test` — 88 passed (181 assertions), including 25 new tests across the three new client test files covering happy paths, GET reads, and `IsNullException` guards.