### PR TITLE
Phase 3: account administration (Webhook, AccountProfile, Password, ApiKey)

### DIFF
--- a/docs/contributing/api-coverage-roadmap.md
+++ b/docs/contributing/api-coverage-roadmap.md
@@ -26,10 +26,10 @@ the order it'll ship in.
 | Sender ID | Create / Read / Update / Delete | ✅ `Hostpinnacle::senderId()->create()/read()/update()/delete()` |
 | Message Template | Create / Read / Update / Delete | ✅ `Hostpinnacle::messageTemplate()->create()/read()/update()/delete()` |
 | Draft | Create / Read / Update / Delete | ✅ `Hostpinnacle::draft()->create()/read()/update()/delete()` |
-| Webhook | Create / Read / Update / Delete | 🔜 Phase 3 |
-| Account profile | Read status / Read profile / Update profile / Read credit history | 🔜 Phase 3 |
-| Password | Change | 🔜 Phase 3 |
-| API Key | Create / Read / Update / Delete | 🔜 Phase 3 |
+| Webhook | Create / Read / Update / Delete | ✅ `Hostpinnacle::webhook()->create()/read()/update()/delete()` |
+| Account profile | Read status / Read profile / Update profile / Read credit history | ✅ `Hostpinnacle::accountProfile()->readStatus()/readProfile()/updateProfile()/readCreditHistory()` |
+| Password | Change | ✅ `Hostpinnacle::password()->change()` |
+| API Key | Create / Read / Update / Delete | ✅ `Hostpinnacle::apiKeys()->create()/read()/update()/delete()` |
 | Contact Group | Create / Read / Update / Delete | 🔜 Phase 4 |
 | Contact | Create / Upload / Read / Update / Delete | 🔜 Phase 4 |
 

--- a/src/Api/AccountProfileClient.php
+++ b/src/Api/AccountProfileClient.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Api;
+
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+
+/**
+ * Account Profile domain: the remote Hostpinnacle account's status, profile, and credit
+ * history. Not Models\HostpinnacleAccount, which is this package's own SaaS storage.
+ */
+class AccountProfileClient extends BaseApiClient
+{
+    /**
+     * Read the account's status.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function readStatus()
+    {
+        return $this->get('/account/readstatus');
+    }
+
+    /**
+     * Read the account's profile.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function readProfile()
+    {
+        return $this->get('/account/readprofile');
+    }
+
+    /**
+     * Update any subset of the account's profile fields.
+     *
+     * @param  array{fullname?: string, address?: string, region?: string, country?: string, city?: string, profilepic?: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function updateProfile($data)
+    {
+        return $this->post('/account/updateprofile', array_filter([
+            'fullname' => $data['fullname'] ?? null,
+            'address' => $data['address'] ?? null,
+            'region' => $data['region'] ?? null,
+            'country' => $data['country'] ?? null,
+            'city' => $data['city'] ?? null,
+            'profilepic' => $data['profilepic'] ?? null,
+        ]));
+    }
+
+    /**
+     * Read the account's credit history within a date range.
+     *
+     * @param  array{fromdate: string, todate: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function readCreditHistory($data)
+    {
+        if (!isset($data['fromdate']) || !isset($data['todate'])) {
+            throw new IsNullException('fromdate and todate must not be null');
+        }
+
+        return $this->post('/account/readcredithistory', [
+            'fromdate' => $data['fromdate'],
+            'todate' => $data['todate'],
+        ]);
+    }
+}

--- a/src/Api/ApiKeyClient.php
+++ b/src/Api/ApiKeyClient.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Api;
+
+/**
+ * API Key domain: manage the API key used to authenticate SMS/API requests.
+ */
+class ApiKeyClient extends BaseApiClient
+{
+    /**
+     * Generate a new API key.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function create()
+    {
+        return $this->post('/apikey/create');
+    }
+
+    /**
+     * Read the current API key.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function read()
+    {
+        return $this->get('/apikey/read');
+    }
+
+    /**
+     * Regenerate the API key.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function update()
+    {
+        return $this->post('/apikey/update');
+    }
+
+    /**
+     * Revoke the API key.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function delete()
+    {
+        return $this->post('/apikey/delete');
+    }
+}

--- a/src/Api/PasswordClient.php
+++ b/src/Api/PasswordClient.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Api;
+
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+
+/**
+ * Password domain: change the Hostpinnacle portal password.
+ */
+class PasswordClient extends BaseApiClient
+{
+    /**
+     * Change the account password.
+     *
+     * @param  array{newpassword: string, confirmpassword: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function change($data)
+    {
+        if (!isset($data['newpassword']) || !isset($data['confirmpassword'])) {
+            throw new IsNullException('newpassword and confirmpassword must not be null');
+        }
+
+        return $this->post('/password/change', [
+            'newpassword' => $data['newpassword'],
+            'confirmpassword' => $data['confirmpassword'],
+        ]);
+    }
+}

--- a/src/Api/WebhookClient.php
+++ b/src/Api/WebhookClient.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Api;
+
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+
+/**
+ * Webhook domain: the endpoint that receives real-time delivery reports (DLR).
+ */
+class WebhookClient extends BaseApiClient
+{
+    /**
+     * Register a webhook endpoint.
+     *
+     * @param  array{smswebhook: string, smswebhookrate?: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function create($data)
+    {
+        if (!isset($data['smswebhook'])) {
+            throw new IsNullException('smswebhook must not be null');
+        }
+
+        return $this->post('/webhook/create', array_filter([
+            'smswebhook' => $data['smswebhook'],
+            'smswebhookrate' => $data['smswebhookrate'] ?? null,
+        ]));
+    }
+
+    /**
+     * Read the configured webhook.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function read()
+    {
+        return $this->get('/webhook/read');
+    }
+
+    /**
+     * Update the webhook endpoint.
+     *
+     * @param  array{smswebhook: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function update($data)
+    {
+        if (!isset($data['smswebhook'])) {
+            throw new IsNullException('smswebhook must not be null');
+        }
+
+        return $this->post('/webhook/update', [
+            'smswebhook' => $data['smswebhook'],
+        ]);
+    }
+
+    /**
+     * Remove the configured webhook.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function delete()
+    {
+        return $this->post('/webhook/delete');
+    }
+}

--- a/src/Hostpinnacle.php
+++ b/src/Hostpinnacle.php
@@ -98,6 +98,46 @@ class Hostpinnacle
     }
 
     /**
+     * Access the Webhook API (create/read/update/delete the DLR webhook endpoint).
+     *
+     * @return \Itsmurumba\Hostpinnacle\Api\WebhookClient
+     */
+    public function webhook(): Api\WebhookClient
+    {
+        return new Api\WebhookClient($this->credentials);
+    }
+
+    /**
+     * Access the Account Profile API (status/profile/credit history of the remote Hostpinnacle account).
+     *
+     * @return \Itsmurumba\Hostpinnacle\Api\AccountProfileClient
+     */
+    public function accountProfile(): Api\AccountProfileClient
+    {
+        return new Api\AccountProfileClient($this->credentials);
+    }
+
+    /**
+     * Access the Password API (change the Hostpinnacle portal password).
+     *
+     * @return \Itsmurumba\Hostpinnacle\Api\PasswordClient
+     */
+    public function password(): Api\PasswordClient
+    {
+        return new Api\PasswordClient($this->credentials);
+    }
+
+    /**
+     * Access the API Key API (create/read/update/delete the API key).
+     *
+     * @return \Itsmurumba\Hostpinnacle\Api\ApiKeyClient
+     */
+    public function apiKeys(): Api\ApiKeyClient
+    {
+        return new Api\ApiKeyClient($this->credentials);
+    }
+
+    /**
      * Build the payload array for Send SMS Batch, Group, or File requests.
      *
      * @param  string|null  $contacts

--- a/tests/Unit/Api/AccountProfileClientTest.php
+++ b/tests/Unit/Api/AccountProfileClientTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Api\AccountProfileClient;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('accountProfile() returns an AccountProfileClient', function () {
+    expect((new Hostpinnacle())->accountProfile())->toBeInstanceOf(AccountProfileClient::class);
+});
+
+test('readStatus() sends get request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/account/readstatus*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->accountProfile()->readStatus();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->method() === 'GET'
+            && str_contains($request->url(), 'https://api.hostpinnacle.test/account/readstatus');
+    });
+});
+
+test('readProfile() sends get request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/account/readprofile*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->accountProfile()->readProfile();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->method() === 'GET'
+            && str_contains($request->url(), 'https://api.hostpinnacle.test/account/readprofile');
+    });
+});
+
+test('updateProfile() sends post request with only the given fields', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/account/updateprofile' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->accountProfile()->updateProfile([
+        'fullname' => 'Testing',
+        'city' => 'Mumbai',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/account/updateprofile'
+            && $request->method() === 'POST'
+            && $request['fullname'] === 'Testing'
+            && $request['city'] === 'Mumbai'
+            && !isset($request['address']);
+    });
+});
+
+test('readCreditHistory() sends post request with date range', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/account/readcredithistory' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->accountProfile()->readCreditHistory([
+        'fromdate' => '2026-08-01',
+        'todate' => '2026-08-31',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/account/readcredithistory'
+            && $request->method() === 'POST'
+            && $request['fromdate'] === '2026-08-01'
+            && $request['todate'] === '2026-08-31';
+    });
+});
+
+test('readCreditHistory() throws IsNullException when fromdate or todate missing', function () {
+    (new Hostpinnacle())->accountProfile()->readCreditHistory(['fromdate' => '2026-08-01']);
+})->throws(IsNullException::class, 'fromdate and todate must not be null');

--- a/tests/Unit/Api/ApiKeyClientTest.php
+++ b/tests/Unit/Api/ApiKeyClientTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Api\ApiKeyClient;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('apiKeys() returns an ApiKeyClient', function () {
+    expect((new Hostpinnacle())->apiKeys())->toBeInstanceOf(ApiKeyClient::class);
+});
+
+test('create() sends post request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/apikey/create' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->apiKeys()->create();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/apikey/create'
+            && $request->method() === 'POST'
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('read() sends get request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/apikey/read*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->apiKeys()->read();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->method() === 'GET'
+            && str_contains($request->url(), 'https://api.hostpinnacle.test/apikey/read');
+    });
+});
+
+test('update() sends post request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/apikey/update' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->apiKeys()->update();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/apikey/update'
+            && $request->method() === 'POST';
+    });
+});
+
+test('delete() sends post request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/apikey/delete' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->apiKeys()->delete();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/apikey/delete'
+            && $request->method() === 'POST';
+    });
+});

--- a/tests/Unit/Api/PasswordClientTest.php
+++ b/tests/Unit/Api/PasswordClientTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Api\PasswordClient;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('password() returns a PasswordClient', function () {
+    expect((new Hostpinnacle())->password())->toBeInstanceOf(PasswordClient::class);
+});
+
+test('change() sends post request with newpassword and confirmpassword', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/password/change' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->password()->change([
+        'newpassword' => 'NewSecret123',
+        'confirmpassword' => 'NewSecret123',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/password/change'
+            && $request->method() === 'POST'
+            && $request['newpassword'] === 'NewSecret123'
+            && $request['confirmpassword'] === 'NewSecret123'
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('change() throws IsNullException when newpassword or confirmpassword missing', function () {
+    (new Hostpinnacle())->password()->change(['newpassword' => 'NewSecret123']);
+})->throws(IsNullException::class, 'newpassword and confirmpassword must not be null');

--- a/tests/Unit/Api/WebhookClientTest.php
+++ b/tests/Unit/Api/WebhookClientTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Api\WebhookClient;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('webhook() returns a WebhookClient', function () {
+    expect((new Hostpinnacle())->webhook())->toBeInstanceOf(WebhookClient::class);
+});
+
+test('create() sends post request with smswebhook and smswebhookrate', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/webhook/create' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->webhook()->create([
+        'smswebhook' => 'https://google.com',
+        'smswebhookrate' => '10',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/webhook/create'
+            && $request->method() === 'POST'
+            && $request['smswebhook'] === 'https://google.com'
+            && $request['smswebhookrate'] === '10'
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('create() omits smswebhookrate when not provided', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/webhook/create' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    (new Hostpinnacle())->webhook()->create(['smswebhook' => 'https://google.com']);
+
+    Http::assertSent(function ($request) {
+        return !isset($request['smswebhookrate']);
+    });
+});
+
+test('create() throws IsNullException when smswebhook is missing', function () {
+    (new Hostpinnacle())->webhook()->create([]);
+})->throws(IsNullException::class, 'smswebhook must not be null');
+
+test('read() sends get request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/webhook/read*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->webhook()->read();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->method() === 'GET'
+            && str_contains($request->url(), 'https://api.hostpinnacle.test/webhook/read');
+    });
+});
+
+test('update() sends post request with smswebhook', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/webhook/update' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->webhook()->update(['smswebhook' => 'https://test.com']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/webhook/update'
+            && $request->method() === 'POST'
+            && $request['smswebhook'] === 'https://test.com';
+    });
+});
+
+test('update() throws IsNullException when smswebhook is missing', function () {
+    (new Hostpinnacle())->webhook()->update([]);
+})->throws(IsNullException::class, 'smswebhook must not be null');
+
+test('delete() sends post request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/webhook/delete' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->webhook()->delete();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/webhook/delete'
+            && $request->method() === 'POST';
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `Api\WebhookClient`, `Api\AccountProfileClient`, `Api\PasswordClient`, `Api\ApiKeyClient` (13 endpoints total), reached via `Hostpinnacle::webhook()`, `::accountProfile()`, `::password()`, `::apiKeys()`.
- `AccountProfileClient` (not `AccountClient`) per the roadmap's naming note — this is the remote Hostpinnacle account's status/profile/credit history, distinct from `Models\HostpinnacleAccount` (this package's own SaaS credential storage).
- `updateProfile()` accepts any subset of fields (fullname/address/region/country/city/profilepic) and only sends what's provided — the collection shows no field as strictly required for a profile update.
- Marks Webhook / Account profile / Password / API Key as ✅ done in the API coverage roadmap.

## Test plan
- [x] `composer test` — 110 passed (220 assertions), including 22 new tests across the four new client test files.