### PR TITLE
Phase 4: audience management (ContactGroup, Contact)

### DIFF
--- a/docs/contributing/api-coverage-roadmap.md
+++ b/docs/contributing/api-coverage-roadmap.md
@@ -13,13 +13,13 @@ the order it'll ship in.
 |---|---|---|
 | Quick SMS | Send | ✅ `Hostpinnacle::sendQuickSMS()` |
 | | Send (scheduled) | ✅ `Hostpinnacle::sendQuickScheduledSMS()` |
-| | Send with link tracking (smartlink) | 🔜 Phase 0 — optional `trackLink`/`smartLinkTitle` keys on `sendQuickSMS()` |
-| Group SMS | Send | ⚠️ `Hostpinnacle::sendGroupSMS()` — sends as **GET**; the API documents this as **POST** with a form body. Fixing in Phase 0. |
-| | Send (scheduled) | ⚠️ `Hostpinnacle::sendGroupScheduledSMS()` — same GET/POST bug |
-| | Send with link tracking (smartlink) | 🔜 Phase 0 — optional keys on `sendGroupSMS()` |
+| | Send with link tracking (smartlink) | ✅ optional `trackLink`/`smartLinkTitle` keys on `sendQuickSMS()` |
+| Group SMS | Send | ✅ `Hostpinnacle::sendGroupSMS()` — POSTs, per the API docs |
+| | Send (scheduled) | ✅ `Hostpinnacle::sendGroupScheduledSMS()` |
+| | Send with link tracking (smartlink) | ✅ optional keys on `sendGroupSMS()` |
 | File upload (mobile only) | Send | ✅ `Hostpinnacle::sendMobileOnlyFileSMS()` |
 | | Send (scheduled) | ✅ `Hostpinnacle::sendMobileOnlyFileScheduledSMS()` |
-| | Send with link tracking (smartlink) | 🔜 Phase 0 — optional keys on `sendMobileOnlyFileSMS()` |
+| | Send with link tracking (smartlink) | ✅ optional keys on `sendMobileOnlyFileSMS()` |
 | File upload (mobile + message) | Send | ✅ `Hostpinnacle::sendMobileAndMessageFileSMS()` |
 | | Send (scheduled) | ✅ `Hostpinnacle::sendMobileAndMessageFileScheduledSMS()` |
 | Schedule | Read / Update / Delete | ✅ `Hostpinnacle::schedule()->read()/update()/delete()` |
@@ -30,11 +30,15 @@ the order it'll ship in.
 | Account profile | Read status / Read profile / Update profile / Read credit history | ✅ `Hostpinnacle::accountProfile()->readStatus()/readProfile()/updateProfile()/readCreditHistory()` |
 | Password | Change | ✅ `Hostpinnacle::password()->change()` |
 | API Key | Create / Read / Update / Delete | ✅ `Hostpinnacle::apiKeys()->create()/read()/update()/delete()` |
-| Contact Group | Create / Read / Update / Delete | 🔜 Phase 4 |
-| Contact | Create / Upload / Read / Update / Delete | 🔜 Phase 4 |
+| Contact Group | Create / Read / Update / Delete | ✅ `Hostpinnacle::contactGroups()->create()/read()/update()/delete()` |
+| Contact | Create / Upload / Read / Update / Delete | ✅ `Hostpinnacle::contacts()->create()/upload()/read()/update()/delete()` |
 
 **Out of scope for now:** the Postman *environment* references an `OTP_SERVER`, but the
 collection has no OTP requests in it. Nothing to implement against until there's a spec.
+
+**Collection quirk:** despite the name, "Upload Contacts" (`/contact/upload`) takes the same
+form fields as Create Contact — no file attachment field in the sample. `ContactClient::upload()`
+matches the collection as-is rather than inventing a multipart variant that isn't documented.
 
 ## Architecture
 

--- a/src/Api/ContactClient.php
+++ b/src/Api/ContactClient.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Api;
+
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+
+/**
+ * Contact domain: individual contacts, optionally assigned to a contact group.
+ */
+class ContactClient extends BaseApiClient
+{
+    /**
+     * Create a contact.
+     *
+     * @param  array{contactname: string, mobileno: string, groupid?: string, groupname?: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function create($data)
+    {
+        if (!isset($data['contactname']) || !isset($data['mobileno'])) {
+            throw new IsNullException('contactname and mobileno must not be null');
+        }
+
+        return $this->post('/contact/create', array_filter([
+            'contactname' => $data['contactname'],
+            'mobileno' => $data['mobileno'],
+            'groupid' => $data['groupid'] ?? null,
+            'groupname' => $data['groupname'] ?? null,
+        ]));
+    }
+
+    /**
+     * Add or update a contact via the upload endpoint. Despite the name, the API takes the
+     * same form fields as create() — there's no file attachment in this endpoint.
+     *
+     * @param  array{contactname: string, mobileno: string, groupid?: string, groupname?: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function upload($data)
+    {
+        if (!isset($data['contactname']) || !isset($data['mobileno'])) {
+            throw new IsNullException('contactname and mobileno must not be null');
+        }
+
+        return $this->post('/contact/upload', array_filter([
+            'contactname' => $data['contactname'],
+            'mobileno' => $data['mobileno'],
+            'groupid' => $data['groupid'] ?? null,
+            'groupname' => $data['groupname'] ?? null,
+        ]));
+    }
+
+    /**
+     * List contacts on the account.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function read()
+    {
+        return $this->get('/contact/read');
+    }
+
+    /**
+     * Update an existing contact.
+     *
+     * @param  array{id: string, contactname: string, mobileno: string, groupid?: string, groupname?: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function update($data)
+    {
+        if (!isset($data['id']) || !isset($data['contactname']) || !isset($data['mobileno'])) {
+            throw new IsNullException('id, contactname and mobileno must not be null');
+        }
+
+        return $this->post('/contact/update', array_filter([
+            'id' => $data['id'],
+            'contactname' => $data['contactname'],
+            'mobileno' => $data['mobileno'],
+            'groupid' => $data['groupid'] ?? null,
+            'groupname' => $data['groupname'] ?? null,
+        ]));
+    }
+
+    /**
+     * Delete one or more contacts by id (comma-separated).
+     *
+     * @param  array{id: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function delete($data)
+    {
+        if (!isset($data['id'])) {
+            throw new IsNullException('id must not be null');
+        }
+
+        return $this->post('/contact/delete', [
+            'id' => $data['id'],
+        ]);
+    }
+}

--- a/src/Api/ContactGroupClient.php
+++ b/src/Api/ContactGroupClient.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Itsmurumba\Hostpinnacle\Api;
+
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+
+/**
+ * Contact Group domain: named groups of contacts (the same "group" sendGroupSMS() sends to).
+ * Named ContactGroupClient, not GroupClient, to read distinctly from the sending verb.
+ */
+class ContactGroupClient extends BaseApiClient
+{
+    /**
+     * Create a contact group.
+     *
+     * @param  array{groupname: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function create($data)
+    {
+        if (!isset($data['groupname'])) {
+            throw new IsNullException('groupname must not be null');
+        }
+
+        return $this->post('/group/create', [
+            'groupname' => $data['groupname'],
+        ]);
+    }
+
+    /**
+     * List contact groups on the account.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function read()
+    {
+        return $this->get('/group/read');
+    }
+
+    /**
+     * Rename an existing contact group.
+     *
+     * @param  array{groupname: string, id: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function update($data)
+    {
+        if (!isset($data['groupname']) || !isset($data['id'])) {
+            throw new IsNullException('groupname and id must not be null');
+        }
+
+        return $this->post('/group/update', [
+            'groupname' => $data['groupname'],
+            'id' => $data['id'],
+        ]);
+    }
+
+    /**
+     * Delete one or more contact groups, by id or by group name (comma-separated).
+     *
+     * @param  array{id?: string, groupname?: string}  $data
+     * @return \Illuminate\Http\Client\Response
+     * @throws IsNullException
+     */
+    public function delete($data)
+    {
+        if (!isset($data['id']) && !isset($data['groupname'])) {
+            throw new IsNullException('id or groupname must not be null');
+        }
+
+        return $this->post('/group/delete', array_filter([
+            'id' => $data['id'] ?? null,
+            'groupname' => $data['groupname'] ?? null,
+        ]));
+    }
+}

--- a/src/Hostpinnacle.php
+++ b/src/Hostpinnacle.php
@@ -138,6 +138,26 @@ class Hostpinnacle
     }
 
     /**
+     * Access the Contact Group API (create/read/update/delete named contact groups).
+     *
+     * @return \Itsmurumba\Hostpinnacle\Api\ContactGroupClient
+     */
+    public function contactGroups(): Api\ContactGroupClient
+    {
+        return new Api\ContactGroupClient($this->credentials);
+    }
+
+    /**
+     * Access the Contact API (create/upload/read/update/delete contacts).
+     *
+     * @return \Itsmurumba\Hostpinnacle\Api\ContactClient
+     */
+    public function contacts(): Api\ContactClient
+    {
+        return new Api\ContactClient($this->credentials);
+    }
+
+    /**
      * Build the payload array for Send SMS Batch, Group, or File requests.
      *
      * @param  string|null  $contacts

--- a/tests/Unit/Api/ContactClientTest.php
+++ b/tests/Unit/Api/ContactClientTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Api\ContactClient;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('contacts() returns a ContactClient', function () {
+    expect((new Hostpinnacle())->contacts())->toBeInstanceOf(ContactClient::class);
+});
+
+test('create() sends post request with contactname and mobileno', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/contact/create' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->contacts()->create([
+        'contactname' => 'TEST NAME',
+        'mobileno' => '911232987678',
+        'groupid' => '1',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/contact/create'
+            && $request->method() === 'POST'
+            && $request['contactname'] === 'TEST NAME'
+            && $request['mobileno'] === '911232987678'
+            && $request['groupid'] === '1'
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('create() throws IsNullException when contactname or mobileno missing', function () {
+    (new Hostpinnacle())->contacts()->create(['contactname' => 'TEST NAME']);
+})->throws(IsNullException::class, 'contactname and mobileno must not be null');
+
+test('upload() sends post request with contactname and mobileno', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/contact/upload' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->contacts()->upload([
+        'contactname' => 'TEST NAME',
+        'mobileno' => '919999999999',
+        'groupname' => 'myGroup',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/contact/upload'
+            && $request->method() === 'POST'
+            && $request['contactname'] === 'TEST NAME'
+            && $request['mobileno'] === '919999999999'
+            && $request['groupname'] === 'myGroup';
+    });
+});
+
+test('upload() throws IsNullException when contactname or mobileno missing', function () {
+    (new Hostpinnacle())->contacts()->upload(['mobileno' => '919999999999']);
+})->throws(IsNullException::class, 'contactname and mobileno must not be null');
+
+test('read() sends get request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/contact/read*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->contacts()->read();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->method() === 'GET'
+            && str_contains($request->url(), 'https://api.hostpinnacle.test/contact/read');
+    });
+});
+
+test('update() sends post request with id, contactname and mobileno', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/contact/update' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->contacts()->update([
+        'id' => '7',
+        'contactname' => 'TEST NAME',
+        'mobileno' => '919999999999',
+        'groupid' => '1',
+    ]);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/contact/update'
+            && $request->method() === 'POST'
+            && $request['id'] === '7'
+            && $request['contactname'] === 'TEST NAME'
+            && $request['mobileno'] === '919999999999'
+            && $request['groupid'] === '1';
+    });
+});
+
+test('update() throws IsNullException when id, contactname, or mobileno missing', function () {
+    (new Hostpinnacle())->contacts()->update(['contactname' => 'TEST NAME', 'mobileno' => '919999999999']);
+})->throws(IsNullException::class, 'id, contactname and mobileno must not be null');
+
+test('delete() sends post request with id', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/contact/delete' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->contacts()->delete(['id' => '4,5,1']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/contact/delete'
+            && $request->method() === 'POST'
+            && $request['id'] === '4,5,1';
+    });
+});
+
+test('delete() throws IsNullException when id missing', function () {
+    (new Hostpinnacle())->contacts()->delete([]);
+})->throws(IsNullException::class, 'id must not be null');

--- a/tests/Unit/Api/ContactGroupClientTest.php
+++ b/tests/Unit/Api/ContactGroupClientTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Itsmurumba\Hostpinnacle\Hostpinnacle;
+use Itsmurumba\Hostpinnacle\Api\ContactGroupClient;
+use Itsmurumba\Hostpinnacle\Exceptions\IsNullException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    hostpinnacle_set_config();
+});
+
+test('contactGroups() returns a ContactGroupClient', function () {
+    expect((new Hostpinnacle())->contactGroups())->toBeInstanceOf(ContactGroupClient::class);
+});
+
+test('create() sends post request with groupname', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/group/create' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->contactGroups()->create(['groupname' => 'myNewGroup']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/group/create'
+            && $request->method() === 'POST'
+            && $request['groupname'] === 'myNewGroup'
+            && $request->hasHeader('apikey', 'test-api-key');
+    });
+});
+
+test('create() throws IsNullException when groupname is missing', function () {
+    (new Hostpinnacle())->contactGroups()->create([]);
+})->throws(IsNullException::class, 'groupname must not be null');
+
+test('read() sends get request', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/group/read*' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->contactGroups()->read();
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->method() === 'GET'
+            && str_contains($request->url(), 'https://api.hostpinnacle.test/group/read');
+    });
+});
+
+test('update() sends post request with groupname and id', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/group/update' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->contactGroups()->update(['groupname' => 'updateGroupName', 'id' => '10']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/group/update'
+            && $request->method() === 'POST'
+            && $request['groupname'] === 'updateGroupName'
+            && $request['id'] === '10';
+    });
+});
+
+test('update() throws IsNullException when groupname or id missing', function () {
+    (new Hostpinnacle())->contactGroups()->update(['groupname' => 'updateGroupName']);
+})->throws(IsNullException::class, 'groupname and id must not be null');
+
+test('delete() sends post request with id', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/group/delete' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->contactGroups()->delete(['id' => '10']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.hostpinnacle.test/group/delete'
+            && $request->method() === 'POST'
+            && $request['id'] === '10';
+    });
+});
+
+test('delete() sends post request with groupname', function () {
+    Http::fake([
+        'https://api.hostpinnacle.test/group/delete' => Http::response(['status' => 'success'], 200),
+    ]);
+
+    $response = (new Hostpinnacle())->contactGroups()->delete(['groupname' => 'group1,group2,group3']);
+
+    expect($response->successful())->toBeTrue();
+    Http::assertSent(function ($request) {
+        return $request['groupname'] === 'group1,group2,group3' && !isset($request['id']);
+    });
+});
+
+test('delete() throws IsNullException when both id and groupname are missing', function () {
+    (new Hostpinnacle())->contactGroups()->delete([]);
+})->throws(IsNullException::class, 'id or groupname must not be null');


### PR DESCRIPTION
## Summary
- Adds `Api\ContactGroupClient` and `Api\ContactClient` (9 endpoints total), reached via `Hostpinnacle::contactGroups()` and `::contacts()`.
- Named `ContactGroupClient`, not `GroupClient`, per the roadmap's naming note — reads distinctly from `sendGroupSMS()`'s "group" of SMS recipients.
- `ContactClient::upload()` matches the Postman collection as-is: despite the name, it's the same form fields as `create()`, no file attachment. Documented as a collection quirk in the roadmap rather than inventing an undocumented multipart variant.
- Fixes stale 🔜/⚠️ markers in the roadmap's status table left over from Phase 0 (those rows were never flipped to ✅ when Phase 0 merged).
- **This completes the API coverage roadmap** — all ~40 endpoints from the Postman collection are now implemented across Phases 0-4.

## Test plan
- [x] `composer test` — 129 passed (256 assertions), including 19 new tests across the two new client test files.