### PR TITLE
Document the account-administration API in the usage guide

### DIFF
--- a/docs/guide/saas-multi-account.md
+++ b/docs/guide/saas-multi-account.md
@@ -37,6 +37,16 @@ $response = Hostpinnacle::for($account)->sendQuickSMS(['mobile' => '254720xxxxxx
 
 You can also pass `HostpinnacleCredentials` to `Hostpinnacle::for($credentials)` if you have a value object instead of a model.
 
+`Hostpinnacle::for($account)` also gives you every account-administration client documented in
+[Usage](/guide/usage#account-administration), scoped to that account's credentials:
+
+```php
+$response = Hostpinnacle::for($account)->schedule()->read([
+    'fromdate' => '2026-08-01',
+    'todate' => '2026-08-31',
+]);
+```
+
 ## Config options (SaaS)
 
 See [Config reference](/reference/config) for the full list. Key options:

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -108,4 +108,165 @@ $data['file'] = $request->file('file');
 $response = $this->hostpinnacle->sendMobileAndMessageFileScheduledSMS($data);
 ```
 
-All methods return an `Illuminate\Http\Client\Response`; use `$response->successful()` or `$response->json()` as needed.
+All `send*` methods return an `Illuminate\Http\Client\Response`; use `$response->successful()` or `$response->json()` as needed. So does every method below.
+
+## Account administration
+
+Beyond sending SMS, `Hostpinnacle` exposes one accessor per account-administration domain.
+Each accessor returns a small client scoped to that domain; every method throws
+`Itsmurumba\Hostpinnacle\Exceptions\IsNullException` if a required field is missing.
+
+### 4. Schedule
+
+Manage previously scheduled sends.
+
+```php
+// List scheduled messages in a date range
+$response = $this->hostpinnacle->schedule()->read([
+    'fromdate' => '2026-08-01',
+    'todate' => '2026-08-31',
+]);
+
+// Reschedule a message
+$response = $this->hostpinnacle->schedule()->update([
+    'uuid' => '1234',
+    'scheduletime' => '2026-08-13 00:09',
+]);
+
+// Cancel a scheduled message
+$response = $this->hostpinnacle->schedule()->delete(['uuid' => '1234']);
+```
+
+### 5. Sender ID
+
+Manage approved sender names.
+
+```php
+$response = $this->hostpinnacle->senderId()->create(['senderid' => 'MYBRAND']);
+$response = $this->hostpinnacle->senderId()->read();
+$response = $this->hostpinnacle->senderId()->update(['senderid' => 'NEWBRAND', 'id' => '69']);
+$response = $this->hostpinnacle->senderId()->delete(['id' => '61,68']); // or ['senderid' => 'ABCDEF1,ABCDEF2']
+```
+
+### 6. Message Template
+
+Manage reusable message bodies.
+
+```php
+$response = $this->hostpinnacle->messageTemplate()->create(['message' => 'Hello ###name###!']);
+$response = $this->hostpinnacle->messageTemplate()->read();
+$response = $this->hostpinnacle->messageTemplate()->update(['message' => 'Updated message', 'id' => '2']);
+$response = $this->hostpinnacle->messageTemplate()->delete(['id' => '2,1']);
+```
+
+### 7. Draft
+
+Manage saved title/content drafts.
+
+```php
+$response = $this->hostpinnacle->draft()->create([
+    'title' => 'Launch announcement',
+    'content' => 'We are live!',
+]);
+$response = $this->hostpinnacle->draft()->read();
+$response = $this->hostpinnacle->draft()->update([
+    'title' => 'Launch announcement (v2)',
+    'content' => 'We are live! Updated.',
+    'id' => '15',
+]);
+$response = $this->hostpinnacle->draft()->delete(['id' => '15,121']);
+```
+
+### 8. Webhook
+
+Manage the endpoint that receives real-time delivery reports (DLR).
+
+```php
+$response = $this->hostpinnacle->webhook()->create([
+    'smswebhook' => 'https://example.com/hostpinnacle/dlr',
+    'smswebhookrate' => '10', // optional
+]);
+$response = $this->hostpinnacle->webhook()->read();
+$response = $this->hostpinnacle->webhook()->update(['smswebhook' => 'https://example.com/new-dlr']);
+$response = $this->hostpinnacle->webhook()->delete();
+```
+
+### 9. Account profile
+
+Read or update the remote Hostpinnacle account's own status, profile, and credit history —
+not to be confused with this package's SaaS `HostpinnacleAccount` model (see
+[SaaS / Multi-Account](/guide/saas-multi-account)).
+
+```php
+$response = $this->hostpinnacle->accountProfile()->readStatus();
+$response = $this->hostpinnacle->accountProfile()->readProfile();
+
+// Only send the fields you want to change
+$response = $this->hostpinnacle->accountProfile()->updateProfile([
+    'fullname' => 'Jane Doe',
+    'city' => 'Nairobi',
+]);
+
+$response = $this->hostpinnacle->accountProfile()->readCreditHistory([
+    'fromdate' => '2026-08-01',
+    'todate' => '2026-08-31',
+]);
+```
+
+### 10. Password
+
+```php
+$response = $this->hostpinnacle->password()->change([
+    'newpassword' => 'new-secret',
+    'confirmpassword' => 'new-secret',
+]);
+```
+
+### 11. API Key
+
+```php
+$response = $this->hostpinnacle->apiKeys()->create();
+$response = $this->hostpinnacle->apiKeys()->read();
+$response = $this->hostpinnacle->apiKeys()->update();
+$response = $this->hostpinnacle->apiKeys()->delete();
+```
+
+### 12. Contact Group
+
+Named groups of contacts — the same groups `sendGroupSMS()` sends to.
+
+```php
+$response = $this->hostpinnacle->contactGroups()->create(['groupname' => 'VIP Customers']);
+$response = $this->hostpinnacle->contactGroups()->read();
+$response = $this->hostpinnacle->contactGroups()->update(['groupname' => 'VIP Customers (Renamed)', 'id' => '10']);
+$response = $this->hostpinnacle->contactGroups()->delete(['id' => '10']); // or ['groupname' => 'group1,group2']
+```
+
+### 13. Contact
+
+Individual contacts, optionally assigned to a contact group.
+
+```php
+$response = $this->hostpinnacle->contacts()->create([
+    'contactname' => 'Jane Doe',
+    'mobileno' => '254720xxxxxx',
+    'groupid' => '1', // optional
+]);
+
+// Same fields as create() — despite the name, the API has no file-upload variant here
+$response = $this->hostpinnacle->contacts()->upload([
+    'contactname' => 'Jane Doe',
+    'mobileno' => '254720xxxxxx',
+    'groupname' => 'VIP Customers', // optional
+]);
+
+$response = $this->hostpinnacle->contacts()->read();
+
+$response = $this->hostpinnacle->contacts()->update([
+    'id' => '7',
+    'contactname' => 'Jane Doe',
+    'mobileno' => '254720xxxxxx',
+]);
+
+$response = $this->hostpinnacle->contacts()->delete(['id' => '4,5,1']);
+```


### PR DESCRIPTION
## Summary
- `docs/guide/usage.md` only documented the original SMS-sending methods. Adds a new "Account administration" section covering all 10 `Api\*` domains shipped in Phases 1-4: Schedule, Sender ID, Message Template, Draft, Webhook, Account profile, Password, API Key, Contact Group, Contact.
- `docs/guide/saas-multi-account.md` gets one added example showing `Hostpinnacle::for($account)` exposes the same account-administration clients, scoped to that account's credentials.
- No new nav/sidebar entries needed — both are existing pages.

## Test plan
- [x] `npm run docs:build` — builds clean, no broken links.